### PR TITLE
Update toml to reflect new mKTL dir structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,34 +2,32 @@
 name = "mKTL"
 version = "0.1.0"
 description = ""
-authors = ["Kyle Lanclos <klanclos@keck.hawaii.edu>",]
+authors = ["Kyle Lanclos <klanclos@keck.hawaii.edu>"]
 readme = "README.md"
-packages = [{include = "mKTL", from = "python/lib"},]
+packages = [{ include = "mKTL", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.4"
+pyzmq = ">=4.0"
+msgspec = { version = ">=0.18", optional = true }
+numpy = { version = ">=1.6", optional = true }
+orjson = { version = ">=3.0", optional = true }
+
+[tool.poetry.extras]
+msgspec = ["msgspec"]
+numpy = ["numpy"]
+orjson = ["orjson"]
+
+[tool.poetry.urls]
+repository = "https://github.com/KeckObservatory/mKTL"
+"Bug Tracker" = "https://github.com/KeckObservatory/mKTL/issues"
+
+[tool.poetry.scripts]
+markguided = { reference = "sbin/markguided", type = "file" }
+markpersistd = { reference = "sbin/markpersistd", type = "file" }
+marksub = { reference = "sbin/markd", type = "file" }
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[project]
-requires-python = ">=3.4"
-dependencies = ["zmq >= 4.0"]
-
-[project.optional-dependencies]
-msgspec = ["msgspec >= 0.18"]
-numpy = ["numpy >= 1.6"]
-orjson = ["orjson >= 3.0"]
-
-[project.urls]
-#homepage = "..."
-repository = "https://github.com/KeckObservatory/mKTL"
-#documentation = "..."
-"Bug Tracker" = "https://github.com/KeckObservatory/mKTL/issues"
-
-[tool.poetry.scripts]
-markguided = {reference = "python/bin/markguided", type = "file"}
-markpersistd = {reference = "python/bin/markpersistd", type = "file"}
-markproxyd = {reference = "python/bin/markproxyd", type = "file"}
-marksub = {reference = "python/bin/marksub", type = "file"}


### PR DESCRIPTION
From PR#1
There was an issue with the current toml since it was mixing two different project metadata formats
Poetry's legacy format ([tool.poetry]) and PEP 621's modern [project] table

Since we can't choose both, and we are using poetry to build, I updated the toml to address this.

```
% pip3 install -e . 
Obtaining file:///Users/lotus/Projects/p/mKTL
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: pyzmq>=4.0 in /Users/lotus/Projects/j/mKTL/env/lib/python3.12/site-packages (from mKTL==0.1.0) (26.4.0)
Building wheels for collected packages: mKTL
  Building editable for mKTL (pyproject.toml) ... done
  Created wheel for mKTL: filename=mktl-0.1.0-py3-none-any.whl size=7664 sha256=fe2c80c9b939f7f2e4f98d3caaa4dba55eeaba51afaaac79f6101cf15a670d4c
  Stored in directory: /private/var/folders/sp/c43knvgn6w9fdxl8pbgl99fm0000gn/T/pip-ephem-wheel-cache-6e03p0qo/wheels/de/0e/c9/d505919ea36fdbdb59ef7c004aee886a205a9f1a99efdcef1b
Successfully built mKTL
Installing collected packages: mKTL
  Attempting uninstall: mKTL
    Found existing installation: mKTL 0.1.0
    Uninstalling mKTL-0.1.0:
      Successfully uninstalled mKTL-0.1.0
Successfully installed mKTL-0.1.0
```