### PR TITLE
mktl.config.save() is now mktl.config.authoritative()

### DIFF
--- a/sbin/mkd
+++ b/sbin/mkd
@@ -83,7 +83,7 @@ def load_configuration(store, alias, filename):
 
     contents = open(filename, 'r').read()
     items = mktl.json.loads(contents)
-    mktl.config.save(store, items, alias)
+    mktl.config.authoritative(store, items, alias)
 
 
 


### PR DESCRIPTION
The entry point for this functionality changed a while back but this reference wasn't updated to use the correct method name. Tyler ran into this when testing an EPICS mKTL interface.