### PR TITLE
Add a built-in item to report the daemon's process ID.

### DIFF
--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -333,6 +333,13 @@ class Daemon:
         items[key]['units'] = 'kilobytes'
         items[key]['settable'] = False
 
+        key = '_' + self.alias + 'pid'
+        items[key] = dict()
+        items[key]['description'] = 'Process identifier (PID) for this daemon.'
+        items[key]['type'] = 'numeric'
+        items[key]['initial'] = os.getpid()
+        items[key]['settable'] = False
+
         self.config.update(block, save=False)
         self.store._update_config()
 


### PR DESCRIPTION
This is for a simple read-only item to report the PID. Example usage:

```
$ ./mk get potpie._potpiepid
_potpiepid: 43077

$ ps -Af|grep 43077
lanclos    43077   43055 14 15:31 pts/6    00:00:02 python3 ./mkd potpie potpie -m potpie.PotPie
```