### PR TITLE
Bad lookups for item configurations

### DIFF
--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -180,7 +180,7 @@ class Configuration:
             fashion.
         """
 
-        item_config = self.config[key]
+        item_config = self[key]
         value = str(value)
         value = value.lower()
         enumerators = item_config['enumerators']
@@ -212,7 +212,7 @@ class Configuration:
             basis.
         """
 
-        item_config = self.config[key]
+        item_config = self[key]
         value = str(value)
         value = value.lower()
 


### PR DESCRIPTION
A few changes to the format handling were trying to use self.config instead of just self to retrieve the per-item configuration.