### PR TITLE
Got the argument order wrong for config.authoritative().

### DIFF
--- a/sbin/mkd
+++ b/sbin/mkd
@@ -83,7 +83,7 @@ def load_configuration(store, alias, filename):
 
     contents = open(filename, 'r').read()
     items = mktl.json.loads(contents)
-    mktl.config.authoritative(store, items, alias)
+    mktl.config.authoritative(store, alias, items)
 
 
 


### PR DESCRIPTION
In the previous pull request I only renamed the method, I didn't confirm the argument order-- and it had changed.