### PR TITLE
Optionally disable ACK and REP responses to SET requests

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -52,12 +52,25 @@ implementation in ZeroMQ, which enforces a strict one request, one response
 pattern; instead, we use DEALER/ROUTER, which allows any amount of messages
 in any order, in any direction.
 
+Upon receipt of a request the daemon will immediately issue an ACK response.
+The absence of a quick response indicates that the daemon is not available,
+and the client should immediately raise an error. After the client receives
+the initial ACK it should then look for the full response. There will be no
+further messages associated with that id number after the full response is
+received. A daemon may choose to forego the ACK response, but should only
+do so in circumstances where processing a request requires zero additional
+processing time.
+
+All requests are handled
+fully asynchronously; a client could send a thousand requests in quick
+succession, but the responses will not be serialized, and the response order
+is not guaranteed. Synchronous behavior, if desired, is implemented by client
+code and not in the protocol itself.
+
 The request/response interaction between the client and daemon is a multipart
-message, where each part is required and has specific meaning. The reference
-implementation provides a :class:`mktl.protocol.message.Message` class to
-minimize the amount of code that has to be aware about the on-the-wire message
-structure. For both ends of the request/response exchange, the message parts
-are:
+message, where each part is required and has specific meaning.
+The message parts are identical for both ends of the request/response
+exchange; the message parts are:
 
 .. list-table::
 
@@ -90,6 +103,26 @@ are:
       is a store or a key, depending on the request; this field will be an empty
       byte sequence if the target is not specified.
 
+  * - **flags**
+    - A big-endian integer representing boolean flags that modify how this
+      message is handled. The default value is an integer zero; if this field
+      is transmitted as an empty byte sequence it must be interpreted as the
+      integer zero. Each bit in the integer has a specific meaning:
+
+      .. list-table::
+
+	 * - *Bit*
+	   - *Name*
+	   - *Meaning*
+
+         * - 0b0001
+           - NO_ACK
+	   - The ACK response to this request should be suppressed.
+
+         * - 0b0010
+           - NO_REP
+	   - The REP response to this request should be suppressed.
+
   * - **payload**
     - The message payload. This is the JSON representation of any additional
       data required as part of this exchange; if setting a new value, it would
@@ -104,21 +137,6 @@ are:
       bytes represent the image buffer, and the JSON payload describes how
       to interpret the buffer. This field will be omitted entirely if there
       is no bulk component.
-
-Upon receipt of a request the daemon will immediately issue an ACK response.
-The absence of a quick response indicates that the daemon is not available,
-and the client should immediately raise an error. After the client receives
-the initial ACK it should then look for the full response. There will be no
-further messages associated with that id number after the full response is
-received. A daemon may choose to forego the ACK response, but should only
-do so in circumstances where processing a request requires zero additional
-processing time.
-
-All requests are handled
-fully asynchronously; a client could send a thousand requests in quick
-succession, but the responses will not be serialized, and the response order
-is not guaranteed. Synchronous behavior, if desired, is implemented by client
-code and not in the protocol itself.
 
 Here is an example of what the full exchange on the client side might look
 like, in this case handling the exchange as a synchronous request::
@@ -137,12 +155,13 @@ like, in this case handling the exchange as a synchronous request::
 	response = self.socket.recv_multipart()
 
 Here is a representation of what the on-the-wire messages might look like
-for the simple exchange outlined above::
+for a simple GET request::
 
 	b'a'
 	b'00000023'
 	b'GET'
 	b'kpfguide.LASTFILENAME'
+	b'\x00'
 	b''
 
 	b'a'
@@ -150,12 +169,18 @@ for the simple exchange outlined above::
 	b'ACK'
 	b''
 	b''
+	b''
 
 	b'a'
 	b'00000023'
 	b'REP'
 	b''
+	b''
 	b'{"value": /sdata1701/kpf1/2025-06-23/image_672.fits', "time": 234.23}'
+
+The reference implementation provides a :class:`mktl.protocol.message.Message`
+class to minimize the amount of code that has to be aware about the on-the-wire
+message structure.
 
 
 .. _message_types:

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -66,11 +66,26 @@ fully asynchronously; a client could send a thousand requests in quick
 succession, but the responses will not be serialized, and the response order
 is not guaranteed. Synchronous behavior, if desired, is implemented by client
 code and not in the protocol itself.
+Here is an example of what the full exchange on the client side might look
+like, in this case handling the exchange as a synchronous request::
+
+        self.socket = zmq_context.socket(zmq.DEALER)
+        self.socket.setsockopt(zmq.LINGER, 0)
+        self.socket.identity = identity.encode()
+        self.socket.connect(daemon)
+
+	self.socket.send_multipart(request)
+	result = self.socket.poll(100) # milliseconds
+	if result == 0:
+	    raise TimeoutError('no response received in 100 ms')
+
+	ack = self.socket.recv_multipart()
+	response = self.socket.recv_multipart()
 
 The request/response interaction between the client and daemon is a multipart
-message, where each part is required and has specific meaning.
+message, where each component of the message has a specific meaning.
 The message parts are identical for both ends of the request/response
-exchange; the message parts are:
+exchange.
 
 .. list-table::
 
@@ -80,6 +95,7 @@ exchange; the message parts are:
   * - **version**
     - A single ASCII character indicating the mKTL protocol version number.
       The initial release of the mKTL protocol uses the version character 'a'.
+      The version identifier is always present.
 
   * - **identifier**
     - A unique identifier for the request. The format of this identifier is
@@ -89,17 +105,18 @@ exchange; the message parts are:
       to the original request. Note that this identifier does not necessarily
       have significance on the daemon side, daemons will use their own internal
       scheme to uniquely identify requests, but the response will always include
-      this original identifier.
+      this original identifier. The request identifier is always present.
 
   * - **type**
     - The message type. This is a short string of characters that identifies
       what type of request, or response, this message represents. It is one
-      of the values described in the :ref:`message_types` section below.
+      of the values described in the :ref:`message_types` section below. The
+      message type is always present.
 
   * - **target**
     - The target for this request/response, if any. Not all requests have a
-      target; responses don't need to specify it, since it is the identification
-      number that ties a response to its request. If a target is specified it
+      target; responses don't need to specify it, since the identifier field
+      associates a response with a request. If a target is specified it
       is a store or a key, depending on the request; this field will be an empty
       byte sequence if the target is not specified.
 
@@ -117,42 +134,27 @@ exchange; the message parts are:
 
          * - 0b0001
            - NO_ACK
-	   - The ACK response to this request should be suppressed.
+	   - Suppress the ACK response to this request.
 
          * - 0b0010
            - NO_REP
-	   - The REP response to this request should be suppressed.
+	   - Suppress the REP response to this request.
 
   * - **payload**
     - The message payload. This is the JSON representation of any additional
       data required as part of this exchange; if setting a new value, it would
       contain the value; if it is a response containing additional information
-      it would go here. This field will be an empty byte sequence if no
-      additional information is required. See the :ref:`message_payload` section
-      for a more complete description of the payload contents.
+      it would go here. See the :ref:`message_payload` section
+      for a more complete description of the payload contents. This field will
+      be an empty byte sequence if there is no payload.
 
   * - **bulk**
     - A bulk byte sequence, typically a component of the payload. This is to
       allow the transmission of information like image data, where the bulk
       bytes represent the image buffer, and the JSON payload describes how
       to interpret the buffer. This field will be omitted entirely if there
-      is no bulk component.
-
-Here is an example of what the full exchange on the client side might look
-like, in this case handling the exchange as a synchronous request::
-
-        self.socket = zmq_context.socket(zmq.DEALER)
-        self.socket.setsockopt(zmq.LINGER, 0)
-        self.socket.identity = identity.encode()
-        self.socket.connect(daemon)
-
-	self.socket.send_multipart(request)
-	result = self.socket.poll(100) # milliseconds
-	if result == 0:
-	    raise zmq.ZMQError('no response received in 100 ms')
-
-	ack = self.socket.recv_multipart()
-	response = self.socket.recv_multipart()
+      is no bulk component, which allows a recipient to distinguish between
+      an empty byte sequence and the complete absence of data.
 
 Here is a representation of what the on-the-wire messages might look like
 for a simple GET request::

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -415,11 +415,13 @@ class RequestServer(mktl.protocol.request.Server):
         """
 
         try:
-            silent = request.payload.silent
+            reply = request.payload.reply
         except:
-            silent = False
+            reply = True
 
-        if silent:
+        if reply:
+            pass
+        else:
             return
 
         self.req_ack(request)

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -415,12 +415,14 @@ class RequestServer(mktl.protocol.request.Server):
         """
 
         try:
-            ack_requested = request.payload.ack
+            silent = request.payload.silent
         except:
-            ack_requested = True
+            silent = False
 
-        if ack_requested:
-            self.req_ack(request)
+        if silent:
+            return
+
+        self.req_ack(request)
 
         type = request.type
         target = request.target

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -414,12 +414,7 @@ class RequestServer(mktl.protocol.request.Server):
             will be generated.
         """
 
-        try:
-            reply = request.payload.reply
-        except:
-            reply = True
-
-        if reply:
+        if request.reply:
             pass
         else:
             return

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -414,7 +414,13 @@ class RequestServer(mktl.protocol.request.Server):
             will be generated.
         """
 
-        self.req_ack(request)
+        try:
+            ack_requested = request.payload.ack
+        except:
+            ack_requested = True
+
+        if ack_requested:
+            self.req_ack(request)
 
         type = request.type
         target = request.target

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -403,11 +403,6 @@ class RequestServer(mktl.protocol.request.Server):
         if request.ack:
             self.req_ack(request)
 
-        if request.reply:
-            pass
-        else:
-            return
-
         type = request.type
         target = request.target
 
@@ -421,7 +416,8 @@ class RequestServer(mktl.protocol.request.Server):
         else:
             raise ValueError('invalid request type: ' + type)
 
-        return payload
+        if request.reply:
+            return payload
 
 
     def req_hash(self, request):

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -400,12 +400,13 @@ class RequestServer(mktl.protocol.request.Server):
             will be generated.
         """
 
+        if request.ack:
+            self.req_ack(request)
+
         if request.reply:
             pass
         else:
             return
-
-        self.req_ack(request)
 
         type = request.type
         target = request.target

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -476,8 +476,8 @@ class RequestServer(protocol.request.Server):
 
 
     def req_handler(self, request):
-        """ Inspect the incoming request type and decide how a response
-            will be generated.
+        """ Inspect the incoming request type and call an appropriate
+            method to handle that specific request.
         """
 
         try:

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -481,11 +481,11 @@ class RequestServer(protocol.request.Server):
         """
 
         try:
-            ack_requested = request.payload.ack
+            silent = request.payload.silent
         except:
-            ack_requested = True
+            silent = False
 
-        if ack_requested:
+        if silent == False:
             self.req_ack(request)
 
         type = request.type
@@ -505,7 +505,10 @@ class RequestServer(protocol.request.Server):
         else:
             raise ValueError('unhandled request type: ' + type)
 
-        return response
+        if silent:
+            return None
+        else:
+            return response
 
 
     def req_get(self, request):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -481,11 +481,11 @@ class RequestServer(protocol.request.Server):
         """
 
         try:
-            silent = request.payload.silent
+            reply = request.payload.reply
         except:
-            silent = False
+            reply = True
 
-        if silent == False:
+        if reply:
             self.req_ack(request)
 
         type = request.type
@@ -505,10 +505,10 @@ class RequestServer(protocol.request.Server):
         else:
             raise ValueError('unhandled request type: ' + type)
 
-        if silent:
-            return None
-        else:
+        if reply:
             return response
+        else:
+            return None
 
 
     def req_get(self, request):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -480,10 +480,7 @@ class RequestServer(protocol.request.Server):
             method to handle that specific request.
         """
 
-        try:
-            reply = request.payload.reply
-        except:
-            reply = True
+        reply = request.reply
 
         if reply:
             self.req_ack(request)

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -480,7 +480,13 @@ class RequestServer(protocol.request.Server):
             will be generated.
         """
 
-        self.req_ack(request)
+        try:
+            ack_requested = request.payload.ack
+        except:
+            ack_requested = True
+
+        if ack_requested:
+            self.req_ack(request)
 
         type = request.type
         target = request.target

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -492,9 +492,7 @@ class RequestServer(protocol.request.Server):
             method to handle that specific request.
         """
 
-        reply = request.reply
-
-        if reply:
+        if request.ack:
             self.req_ack(request)
 
         type = request.type
@@ -514,7 +512,7 @@ class RequestServer(protocol.request.Server):
         else:
             raise ValueError('unhandled request type: ' + type)
 
-        if reply:
+        if request.reply:
             return response
         else:
             return None

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -647,15 +647,18 @@ class Item:
         return payload
 
 
-    def set(self, new_value, wait=True, formatted=False, quantity=False):
+    def set(self, new_value, wait=True, response=True, formatted=False, quantity=False):
         """ Set a new value. Set *wait* to True to block until the request
             completes; this is the default behavior. If *wait* is set to False,
             the caller will be returned a :class:`mktl.protocol.message.Request`
             instance, which has a :func:`mktl.protocol.message.Request.wait`
             method that can optionally be invoked to block until completion of
             the request; the wait will return immediately once the request is
-            satisfied. There is no return value for a blocking request; failed
-            requests will raise exceptions.
+            satisfied. Set *response* to False to disable all error handling and
+            acknowledgements for the request (fire and forget); setting
+            *response* to False implies *wait* is also False.
+            There is no return value for a blocking request; failed requests
+            will raise exceptions.
 
             The optional *formatted* and *quantity* options enable calling
             :func:`set` with either the string-formatted representation or
@@ -684,10 +687,11 @@ class Item:
         else:
             raise ValueError('formatted+quantity arguments must be boolean')
 
-        if wait == False:
-            payload = self.to_payload(new_value, ack=False)
-        else:
+        if response:
             payload = self.to_payload(new_value)
+        else:
+            payload = self.to_payload(new_value, ack=False)
+            wait = False
 
         message = protocol.message.Request('SET', self.full_key, payload)
         self.req.send(message)

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -647,16 +647,16 @@ class Item:
         return payload
 
 
-    def set(self, new_value, wait=True, silent=False, formatted=False, quantity=False):
+    def set(self, new_value, wait=True, reply=True, formatted=False, quantity=False):
         """ Set a new value. Set *wait* to True to block until the request
             completes; this is the default behavior. If *wait* is set to False,
             the caller will be returned a :class:`mktl.protocol.message.Request`
             instance, which has a :func:`mktl.protocol.message.Request.wait`
             method that can optionally be invoked to block until completion of
             the request; the wait will return immediately once the request is
-            satisfied. Set *silent* to False to disable all error handling and
+            satisfied. Set *reply* to False to disable all error handling and
             acknowledgements for the request (fire and forget); setting
-            *silent* to True implies *wait* is also False.
+            *reply to False implies *wait* is also False.
             There is no return value for a blocking request; failed requests
             will raise exceptions.
 
@@ -687,11 +687,11 @@ class Item:
         else:
             raise ValueError('formatted+quantity arguments must be boolean')
 
-        if silent:
-            payload = self.to_payload(new_value, silent=True)
-            wait = False
-        else:
+        if reply:
             payload = self.to_payload(new_value)
+        else:
+            payload = self.to_payload(new_value, reply=False)
+            wait = False
 
         message = protocol.message.Request('SET', self.full_key, payload)
         self.req.send(message)

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -684,7 +684,11 @@ class Item:
         else:
             raise ValueError('formatted+quantity arguments must be boolean')
 
-        payload = self.to_payload(new_value)
+        if wait == False:
+            payload = self.to_payload(new_value, ack=False)
+        else:
+            payload = self.to_payload(new_value)
+
         message = protocol.message.Request('SET', self.full_key, payload)
         self.req.send(message)
 
@@ -821,7 +825,7 @@ class Item:
         return formatted
 
 
-    def to_payload(self, value=None, timestamp=None):
+    def to_payload(self, value=None, timestamp=None, **kwargs):
         """ Interpret the provided arguments into a
             :class:`mktl.protocol.message.Payload` instance; if the *value* is
             not specified the current value of this :class:`Item` will be
@@ -857,11 +861,11 @@ class Item:
             bulk = value.tobytes()
         except AttributeError:
             bulk = None
-            payload = protocol.message.Payload(value, timestamp)
+            payload = protocol.message.Payload(value, timestamp, **kwargs)
         else:
             shape = value.shape
             dtype = str(value.dtype)
-            payload = protocol.message.Payload(None, timestamp, bulk=bulk, shape=shape, dtype=dtype)
+            payload = protocol.message.Payload(None, timestamp, bulk=bulk, shape=shape, dtype=dtype, **kwargs)
 
         return payload
 

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -647,16 +647,16 @@ class Item:
         return payload
 
 
-    def set(self, new_value, wait=True, response=True, formatted=False, quantity=False):
+    def set(self, new_value, wait=True, silent=False, formatted=False, quantity=False):
         """ Set a new value. Set *wait* to True to block until the request
             completes; this is the default behavior. If *wait* is set to False,
             the caller will be returned a :class:`mktl.protocol.message.Request`
             instance, which has a :func:`mktl.protocol.message.Request.wait`
             method that can optionally be invoked to block until completion of
             the request; the wait will return immediately once the request is
-            satisfied. Set *response* to False to disable all error handling and
+            satisfied. Set *silent* to False to disable all error handling and
             acknowledgements for the request (fire and forget); setting
-            *response* to False implies *wait* is also False.
+            *silent* to True implies *wait* is also False.
             There is no return value for a blocking request; failed requests
             will raise exceptions.
 
@@ -687,11 +687,11 @@ class Item:
         else:
             raise ValueError('formatted+quantity arguments must be boolean')
 
-        if response:
-            payload = self.to_payload(new_value)
-        else:
-            payload = self.to_payload(new_value, ack=False)
+        if silent:
+            payload = self.to_payload(new_value, silent=True)
             wait = False
+        else:
+            payload = self.to_payload(new_value)
 
         message = protocol.message.Request('SET', self.full_key, payload)
         self.req.send(message)

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -701,14 +701,17 @@ class Item:
         else:
             raise ValueError('formatted+quantity arguments must be boolean')
 
+        payload = self.to_payload(new_value)
+
         if reply:
-            payload = self.to_payload(new_value)
+            flags = None
             payload.add_origin()
         else:
-            payload = self.to_payload(new_value, reply=False)
+            flags = protocol.message.NO_ACK | protocol.message.NO_REPLY
             wait = False
 
-        message = protocol.message.Request('SET', self.full_key, payload)
+        key = self.full_key
+        message = protocol.message.Request('SET', key, payload, flags=flags)
         self.req.send(message)
 
         if wait == False:

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -707,7 +707,7 @@ class Item:
             flags = None
             payload.add_origin()
         else:
-            flags = protocol.message.NO_ACK | protocol.message.NO_REPLY
+            flags = protocol.message.NO_ACK_OR_REP
             wait = False
 
         key = self.full_key

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -375,6 +375,30 @@ class Payload:
         return payload
 
 
+    @property
+    def reply(self):
+        """ The reply attribute is generally only set to indicate that a
+            reply is not necessary. Establishing a property to return the
+            current value allows the exception handling to be done once,
+            here, and not everywhere the reply attribute might be inspected.
+            By a happy coincidence, the existence of this property does not
+            trigger the inclusion of 'reply' in the output of vars(), which
+            is how the :func:`encapsulate` method determines which local
+            attributes to include in the final output.
+        """
+
+        try:
+            return self.__reply
+        except AttributeError:
+            # Message replies are enabled by default.
+            return True
+
+
+    @reply.setter
+    def reply(self, new_value):
+        self.__reply = new_value
+
+
 # end of class Payload
 
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -128,6 +128,21 @@ class Message:
         self._parts = parts
 
 
+    @property
+    def reply(self):
+        """ The payload reply attribute is mirrored here for the sake of
+            simplifying exception handling elsewhere in the mKTL code base.
+            Otherwise, the other code would need to catch the AttributeError
+            thrown when the local payload is None.
+        """
+
+        try:
+            return self.payload.reply
+        except AttributeError:
+            # There is no payload, and message replies are enabled by default.
+            return True
+
+
 # end of class Message
 
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -19,6 +19,11 @@ from .. import json
 
 version = b'a'
 
+# Define any/all optional flags for message handling.
+
+NO_ACK = 0b1
+NO_REPLY = 0b10
+
 # The cached origin information is used by the Payload class to (optionally)
 # provide information used to determine the origin of a message. The call to
 # os.getlogin() appears to be more expensive than the others. For that reason
@@ -77,7 +82,7 @@ class Message:
 
     valid_types = set(('ACK', 'REP'))
 
-    def __init__(self, type, target=None, payload=None, id=None):
+    def __init__(self, type, target=None, payload=None, id=None, flags=None):
 
         if type in self.valid_types:
             pass
@@ -88,6 +93,7 @@ class Message:
         # for example, publish messages do not have or need an identification
         # number or a prefix.
 
+        self.flags = flags
         self.id = id
         self.type = type
         self.payload = payload
@@ -118,10 +124,16 @@ class Message:
             # Once finalized, always finalized.
             return
 
+        flags = self.flags
         id = self.id
         type = self.type
         target = self.target
         payload = self.payload
+
+        if flags:
+            flags = flags.to_bytes(byteorder='big')
+        else:
+            flags = b'\x00'
 
         # It is legal to create a Message with None as the id-- this happens
         # all the time when a Message is used as a container-- but trying to
@@ -157,9 +169,9 @@ class Message:
             payload = payload.encapsulate()
 
         if self.prefix:
-            parts = self.prefix + (version, id, type, target, payload, bulk)
+            parts = self.prefix + (version, id, flags, type, target, payload, bulk)
         else:
-            parts = (version, id, type, target, payload, bulk)
+            parts = (version, id, flags, type, target, payload, bulk)
 
         self._parts = parts
 
@@ -197,16 +209,10 @@ class Message:
 
     @property
     def reply(self):
-        """ The payload reply attribute is mirrored here for the sake of
-            simplifying exception handling elsewhere in the mKTL code base.
-            Otherwise, the other code would need to catch the AttributeError
-            thrown when the local payload is None.
-        """
 
-        try:
-            return self.payload.reply
-        except AttributeError:
-            # There is no payload, and message replies are enabled by default.
+        if self.flags and self.flags & NO_REPLY:
+            return False
+        else:
             return True
 
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -114,6 +114,15 @@ class Message:
         return repr(self._parts)
 
 
+    @property
+    def ack(self):
+
+        if self.flags and self.flags & NO_ACK:
+            return False
+        else:
+            return True
+
+
     def _finalize(self):
         """ Take the contents of this :class:`Message`, interpet them as
             bytes, and prepare the tuple that will be used for the multipart

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -167,7 +167,7 @@ class Message:
         if flags:
             flags = flags.to_bytes(byteorder='big')
         else:
-            flags = b'\x00'
+            flags = b''
 
         if payload is None or payload == '':
             bulk = None
@@ -249,9 +249,13 @@ class Message:
         except IndexError:
             bulk = None
 
-        flags = int.from_bytes(flags, byteorder='big')
         type = type.decode()
         target = target.decode()
+
+        if flags == b'':
+            flags = None
+        else:
+            flags = int.from_bytes(flags, byteorder='big')
 
         if payload == b'':
             payload = None

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -140,11 +140,6 @@ class Message:
         target = self.target
         payload = self.payload
 
-        if flags:
-            flags = flags.to_bytes(byteorder='big')
-        else:
-            flags = b'\x00'
-
         # It is legal to create a Message with None as the id-- this happens
         # all the time when a Message is used as a container-- but trying to
         # send such a message is not permitted.
@@ -169,6 +164,11 @@ class Message:
                 # Assume it is already bytes.
                 pass
 
+        if flags:
+            flags = flags.to_bytes(byteorder='big')
+        else:
+            flags = b'\x00'
+
         if payload is None or payload == '':
             bulk = None
             payload = b''
@@ -180,9 +180,9 @@ class Message:
         # be represented as None, distinct from being an empty byte sequence.
 
         if bulk is None:
-            parts = (version, id, flags, type, target, payload)
+            parts = (version, id, type, target, flags, payload)
         else:
-            parts = (version, id, flags, type, target, payload, bulk)
+            parts = (version, id, type, target, flags, payload, bulk)
 
         if self.prefix:
             parts = self.prefix + parts
@@ -238,10 +238,10 @@ class Message:
         if their_version != version:
             raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
 
-        message_id = parts[1]
-        message_flags = parts[2]
-        message_type = parts[3]
-        target = parts[4]
+        id = parts[1]
+        type = parts[2]
+        target = parts[3]
+        flags = parts[4]
         payload = parts[5]
 
         try:
@@ -249,8 +249,8 @@ class Message:
         except IndexError:
             bulk = None
 
-        message_flags = int.from_bytes(message_flags, byteorder='big')
-        message_type = message_type.decode()
+        flags = int.from_bytes(flags, byteorder='big')
+        type = type.decode()
         target = target.decode()
 
         if payload == b'':
@@ -264,7 +264,7 @@ class Message:
                 # allow it to pass, assuming the users know what they're doing.
                 pass
 
-        message = cls(message_type, target, payload, message_id, message_flags)
+        message = cls(type, target, payload, id, flags)
         return message
 
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -393,7 +393,7 @@ class Request(Message):
         if id is None:
             id = _id_next()
 
-        Message.__init__(self, type, target, payload, id)
+        Message.__init__(self, type, target, payload, id, flags)
 
         self.response = None
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -22,8 +22,8 @@ version = b'a'
 # Define any/all optional flags for message handling.
 
 NO_ACK = 0b1
-NO_REPLY = 0b10
-NO_ACK_OR_REP = NO_ACK | NO_REPLY
+NO_REP = 0b10
+NO_ACK_OR_REP = NO_ACK | NO_REP
 
 # The cached origin information is used by the Payload class to (optionally)
 # provide information used to determine the origin of a message. The call to
@@ -271,7 +271,7 @@ class Message:
     @property
     def reply(self):
 
-        if self.flags and self.flags & NO_REPLY:
+        if self.flags and self.flags & NO_REP:
             return False
         else:
             return True

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -220,8 +220,8 @@ class Message:
 
         quantity = len(parts)
 
-        if quantity != 5 and quantity != 6:
-            raise ValueError("expected 5 or 6 parts, got %d" % (quantity))
+        if quantity != 6 and quantity != 7:
+            raise ValueError("expected 6 or 7 parts, got %d" % (quantity))
 
         their_version = parts[0]
 
@@ -229,15 +229,17 @@ class Message:
             raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
 
         message_id = parts[1]
-        message_type = parts[2]
-        target = parts[3]
-        payload = parts[4]
+        message_flags = parts[2]
+        message_type = parts[3]
+        target = parts[4]
+        payload = parts[5]
 
         try:
-            bulk = parts[5]
+            bulk = parts[6]
         except IndexError:
             bulk = None
 
+        message_flags = int.from_bytes(message_flags, byteorder='big')
         message_type = message_type.decode()
         target = target.decode()
 
@@ -252,7 +254,7 @@ class Message:
                 # allow it to pass, assuming the users know what they're doing.
                 pass
 
-        message = cls(message_type, target, payload, message_id)
+        message = cls(message_type, target, payload, message_id, message_flags)
         return message
 
 
@@ -367,7 +369,7 @@ class Request(Message):
 
     valid_types = set(('CONFIG', 'GET', 'HASH', 'SET'))
 
-    def __init__(self, type, target=None, payload=None, id=None):
+    def __init__(self, type, target=None, payload=None, id=None, flags=None):
 
         # Requests are generally initiated without an id number, but they're
         # required to have one. The expectation is that requests will have an

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -23,6 +23,7 @@ version = b'a'
 
 NO_ACK = 0b1
 NO_REPLY = 0b10
+NO_ACK_OR_REP = NO_ACK | NO_REPLY
 
 # The cached origin information is used by the Payload class to (optionally)
 # provide information used to determine the origin of a message. The call to

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -583,30 +583,6 @@ class Payload:
         return payload
 
 
-    @property
-    def reply(self):
-        """ The reply attribute is generally only set to indicate that a
-            reply is not necessary. Establishing a property to return the
-            current value allows the exception handling to be done once,
-            here, and not everywhere the reply attribute might be inspected.
-            By a happy coincidence, the existence of this property does not
-            trigger the inclusion of 'reply' in the output of vars(), which
-            is how the :func:`encapsulate` method determines which local
-            attributes to include in the final output.
-        """
-
-        try:
-            return self.__reply
-        except AttributeError:
-            # Message replies are enabled by default.
-            return True
-
-
-    @reply.setter
-    def reply(self, new_value):
-        self.__reply = new_value
-
-
 # end of class Payload
 
 

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -201,14 +201,14 @@ class Client:
         self.request_signal.send(b'')
 
         try:
-            ack_requested = message.payload.ack
+            silent = message.payload.silent
         except:
-            ack_requested = True
+            silent = False
 
-        if ack_requested:
-            ack = message.wait_ack(self.timeout)
-        else:
+        if silent:
             return
+
+        ack = message.wait_ack(self.timeout)
 
         if ack == False:
             error = '%s @ %s:%d: no response received in %.2f sec'
@@ -369,12 +369,14 @@ class Server:
         """
 
         try:
-            ack_requested = request.payload.ack
+            silent = request.payload.silent
         except:
-            ack_requested = True
+            silent = False
 
-        if ack_requested:
-            self.req_ack(request)
+        if silent:
+            return
+
+        self.req_ack(request)
 
         response = message.Message('REP', target, id=request.id)
         response.prefix = request.prefix

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -200,12 +200,7 @@ class Client:
         self.requests.put(message)
         self.request_signal.send(b'')
 
-        try:
-            reply = message.payload.reply
-        except:
-            reply = True
-
-        if reply:
+        if message.reply:
             pass
         else:
             return
@@ -370,12 +365,7 @@ class Server:
             structure of what's happening in the daemon code.
         """
 
-        try:
-            reply = request.payload.reply
-        except:
-            reply = True
-
-        if reply:
+        if request.reply:
             pass
         else:
             return

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -175,12 +175,12 @@ class Client:
 
         while True:
             sockets = poller.poll(10000) # milliseconds
-            for socket, flag in sockets:
+            for active, flag in sockets:
 
-                if self.request_receive == socket:
+                if self.request_receive == active:
                     self._req_outgoing()
 
-                elif self.socket == socket:
+                elif self.socket == active:
                     parts = self.socket.recv_multipart()
                     self._rep_incoming(parts)
 

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -127,7 +127,7 @@ class Client:
                 # allow it to pass, assuming the users know what they're doing.
                 pass
 
-        response = message.Message('REP', target, payload, response_id)
+        response = message.Message('REP', target, payload, id=response_id)
         pending._complete(response)
         del self.pending[response_id]
 
@@ -415,7 +415,7 @@ class Server:
                 # allow it to pass, assuming the users know what they're doing.
                 pass
 
-        request = message.Request(req_type, target, payload, req_id)
+        request = message.Request(req_type, target, payload, id=req_id)
         request.prefix = (ident,)
         payload = None
         error = None
@@ -442,7 +442,7 @@ class Server:
             elif payload.error is None:
                 payload.error = error
 
-        response = message.Message('REP', target, payload, req_id)
+        response = message.Message('REP', target, payload, id=req_id)
         response.prefix = request.prefix
 
         self.send(response)

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -450,7 +450,8 @@ class Server:
         if payload is None and error is None:
             # The handler should only return None when no response is
             # immediately forthcoming-- the handler has invoked some
-            # other processing chain that will issue a proper response.
+            # other processing chain that will issue a proper response,
+            # or the client explicitly requested no response.
             return
 
         if error is not None:

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -483,6 +483,9 @@ class Server:
                 elif self.socket == active:
                     parts = self.socket.recv_multipart()
                     # Calling submit() will block if a worker is not available.
+                    # Note that for high frequency operations this can result
+                    # in out-of-order handling of requests, for example, if a
+                    # stream of SET requests are inbound for a single item.
                     self.workers.submit(self.req_incoming, parts)
 
 

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -201,11 +201,13 @@ class Client:
         self.request_signal.send(b'')
 
         try:
-            silent = message.payload.silent
+            reply = message.payload.reply
         except:
-            silent = False
+            reply = True
 
-        if silent:
+        if reply:
+            pass
+        else:
             return
 
         ack = message.wait_ack(self.timeout)
@@ -369,11 +371,13 @@ class Server:
         """
 
         try:
-            silent = request.payload.silent
+            reply = request.payload.reply
         except:
-            silent = False
+            reply = True
 
-        if silent:
+        if reply:
+            pass
+        else:
             return
 
         self.req_ack(request)

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -182,7 +182,7 @@ class Client:
         self.requests.put(message)
         self.request_signal.send(b'')
 
-        if message.reply:
+        if message.ack:
             pass
         else:
             return
@@ -347,12 +347,14 @@ class Server:
             structure of what's happening in the daemon code.
         """
 
+
+        if request.ack:
+            self.req_ack(request)
+
         if request.reply:
             pass
         else:
             return
-
-        self.req_ack(request)
 
         response = message.Message('REP', target, id=request.id)
         response.prefix = request.prefix


### PR DESCRIPTION
This pull request disables all responses from the server that would normally be triggered in response to a SET request. If a normal blocking SET request can be issued 5000 times per second, a client not waiting for a full response can instead issue 5500 requests per second, a client not waiting for _any_ response can issue 40000 requests per second.