### PR TITLE
Override perform_get() and perform_set() without a subclass

### DIFF
--- a/doc/example/daemon.rst
+++ b/doc/example/daemon.rst
@@ -4,7 +4,9 @@ Daemon: basics
 ==============
 
 This example will establish a 'metal' store and items intended to portray
-market prices for various precious metals.
+market prices for various precious metals. Refer to the :ref:`unabridged_daemon`
+example to see these different aspects of a daemon presented in a single
+block of code.
 
 
 Getting started

--- a/doc/example/daemon_unabridged.rst
+++ b/doc/example/daemon_unabridged.rst
@@ -1,3 +1,5 @@
+.. _unabridged_daemon:
+
 Daemon: unabridged
 ==================
 

--- a/doc/item.rst
+++ b/doc/item.rst
@@ -41,6 +41,9 @@ The Item class
    is used in a daemon context. The following methods have utility when
    a daemon is authoritative for an item.
 
+   .. automethod:: add_performer
+   .. automethod:: add_get_performer
+   .. automethod:: add_set_performer
    .. automethod:: from_payload
    .. automethod:: poll
    .. automethod:: publish

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -178,8 +178,9 @@ class Daemon:
 
     def add_get_handler(self, key, method):
         """ Define a method that will be called for all GET requests for
-            the specified item. Refer to :func:`add_handlers` for additional
-            details.
+            the specified item. See :func:`mktl.Item.req_get` for additional
+            details; inspection of the implementation for that method is
+            recommended to ensure all the necessary actions are covered.
         """
 
         try:
@@ -349,8 +350,9 @@ class Daemon:
 
     def add_set_handler(self, key, method):
         """ Define a method that will be called for all SET requests for
-            the specified item. Refer to :func:`add_handlers` for additional
-            details.
+            the specified item. See :func:`mktl.Item.req_set` for additional
+            details; inspection of the implementation for that method is
+            recommended to ensure all the necessary actions are covered.
         """
 
         try:

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -176,54 +176,6 @@ class Daemon:
         self.logger.debug("daemon initialization complete")
 
 
-    def add_item(self, item_class, key, **kwargs):
-        """ Add an :class:`mktl.Item` to this daemon instance; this is the entry
-            point for establishing an authoritative item, one that will handle
-            inbound get/set request and the like. The *kwargs* will be passed
-            directly to the *item_class* when it is called to be instantiated.
-        """
-
-        key = key.lower()
-
-        try:
-            self.config.authoritative_items[key]
-        except KeyError:
-            raise KeyError("this daemon is not authoritative for the key '%s'" %(key))
-
-        existing = self.store._items[key]
-
-        if existing is not None:
-            if existing.authoritative:
-                raise RuntimeError('duplicate item not allowed: ' + key)
-
-            # It's possible that some other item registered callbacks against
-            # this item before the local, authoritative variant could be
-            # established; we'll want to preserve the callbacks established
-            # on that previous item while replacing it with the authoritative
-            # variant.
-
-            preserved_callbacks = existing.callbacks
-            existing._cleanup()
-            del existing
-        else:
-            preserved_callbacks = tuple()
-
-
-        kwargs['authoritative'] = True
-        kwargs['pub'] = self.pub
-        created = item_class(self.store, key, **kwargs)
-
-        # Instantiating the item results in a persistent reference in
-        # self.store._items, there is no need to manipulate that dictionary
-        # directly.
-
-        for reference in preserved_callbacks:
-            callback = reference()
-
-            if callback:
-                created.register(callback)
-
-
     def add_handlers(self, handlers):
         """ This method is intended to be a single call, accepting a sequence
             of triplets mapping external methods handling GET and SET
@@ -275,6 +227,53 @@ class Daemon:
             else:
                 raise ValueError("request must be either 'get' or 'set'")
 
+
+    def add_item(self, item_class, key, **kwargs):
+        """ Add an :class:`mktl.Item` to this daemon instance; this is the entry
+            point for establishing an authoritative item, one that will handle
+            inbound get/set request and the like. The *kwargs* will be passed
+            directly to the *item_class* when it is called to be instantiated.
+        """
+
+        key = key.lower()
+
+        try:
+            self.config.authoritative_items[key]
+        except KeyError:
+            raise KeyError("this daemon is not authoritative for the key '%s'" %(key))
+
+        existing = self.store._items[key]
+
+        if existing is not None:
+            if existing.authoritative:
+                raise RuntimeError('duplicate item not allowed: ' + key)
+
+            # It's possible that some other item registered callbacks against
+            # this item before the local, authoritative variant could be
+            # established; we'll want to preserve the callbacks established
+            # on that previous item while replacing it with the authoritative
+            # variant.
+
+            preserved_callbacks = existing.callbacks
+            existing._cleanup()
+            del existing
+        else:
+            preserved_callbacks = tuple()
+
+
+        kwargs['authoritative'] = True
+        kwargs['pub'] = self.pub
+        created = item_class(self.store, key, **kwargs)
+
+        # Instantiating the item results in a persistent reference in
+        # self.store._items, there is no need to manipulate that dictionary
+        # directly.
+
+        for reference in preserved_callbacks:
+            callback = reference()
+
+            if callback:
+                created.register(callback)
 
 
     def add_performers(self, performers):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -224,10 +224,63 @@ class Daemon:
                 created.register(callback)
 
 
+    def add_handlers(self, handlers):
+        """ This method is intended to be a single call, accepting a sequence
+            of triplets mapping external methods handling GET and SET
+            requests, bypassing the usual handling chain involving
+            :class:`mktl.Item` instances.
+
+            A triplet is the key for an item (including the store name), whether
+            this is a 'get' or a 'set' handler, and a valid reference to a
+            method. For example::
+
+                ('maunakea.temperature', 'get', mkwc.get_temperature)
+
+            See :func:`mktl.Item.req_get` and
+            :func:`mktl.Item.req_set` for additional details; inspection of
+            the implementation for those methods is recommended to ensure all
+            the necessary actions are covered.
+        """
+
+        for triplet in handlers:
+            full_key,request,method = triplet
+
+            full_key = full_key.lower()
+            full_key = full_key.strip()
+
+            # Allow this method to be called before placeholder Item instances
+            # have been established. The use of external handler methods
+            # implies the caller will not be instantiating custom Item
+            # subclasses; instantiating them now ensures any custom code is
+            # exclusive.
+
+            store,key = full_key.split('.', 1)
+
+            try:
+                existing = self.store._items[key]
+            except KeyError:
+                raise KeyError('this daemon does not contain ' + repr(key))
+
+            if existing is None or existing.authoritative == False:
+                self.add_item(item.Item, key)
+
+
+            request = request.lower()
+            request = request.strip()
+
+            if request == 'get':
+                self.rep._req_get_handlers[full_key] = method
+            elif request == 'set':
+                return self.add_set_performer(method)
+            else:
+                raise ValueError("request must be either 'get' or 'set'")
+
+
+
     def add_performers(self, performers):
         """ This method is intended to be a single call, accepting a sequence
             of triplets mapping external methods performing GET and SET
-            requests back to the :class:`mktl.Item` instances receiving those
+            requests onto the :class:`mktl.Item` instances receiving those
             requests from this daemon.
 
             A triplet is the key for an item (omitting the store name), whether
@@ -243,11 +296,12 @@ class Daemon:
         for triplet in performers:
             key,request,method = triplet
 
-            # Allow this method to be called before placeolder Item instances
+            # Allow this method to be called before placeholder Item instances
             # have been established. The use of external performer methods,
             # rather than overriding Item.perform_get() and Item.perform_set(),
             # implies the caller will not be instantiating custom Item
-            # subclasses.
+            # subclasses; instantiating them now ensures any custom code is
+            # exclusive.
 
             try:
                 existing = self.store._items[key]
@@ -501,8 +555,8 @@ class RequestServer(protocol.request.Server):
         protocol.request.Server.__init__(self, *args, **kwargs)
         self.daemon = daemon
 
-        self._req_get_methods = dict()
-        self._req_set_methods = dict()
+        self._req_get_handlers = dict()
+        self._req_set_handlers = dict()
 
 
     def req_config(self, request):
@@ -557,7 +611,7 @@ class RequestServer(protocol.request.Server):
     def req_get(self, request):
 
         try:
-            getter = self._req_get_methods[request.target]
+            getter = self._req_get_handlers[request.target]
         except KeyError:
             pass
         else:
@@ -576,7 +630,7 @@ class RequestServer(protocol.request.Server):
             raise KeyError('this daemon does not contain ' + repr(key))
 
         getter = self.daemon.store[key].req_get
-        self._req_get_methods[request.target] = getter
+        self._req_get_handlers[request.target] = getter
         return getter(request)
 
 
@@ -592,7 +646,7 @@ class RequestServer(protocol.request.Server):
         ### a leading 'set:' topic.
 
         try:
-            setter = self._req_set_methods[request.target]
+            setter = self._req_set_handlers[request.target]
         except KeyError:
             pass
         else:
@@ -611,7 +665,7 @@ class RequestServer(protocol.request.Server):
             raise KeyError('this daemon does not contain ' + repr(key))
 
         setter = self.daemon.store[key].req_set
-        self._req_set_methods[request.target] = setter
+        self._req_set_handlers[request.target] = setter
         return setter(request)
 
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -232,9 +232,9 @@ class Daemon:
         request = request.strip()
 
         if request == 'get':
-            self.add_get_request(key, method)
+            self.add_get_handler(key, method)
         elif request == 'set':
-            self.add_set_request(key, method)
+            self.add_set_handler(key, method)
         else:
             raise ValueError("request must be either 'get' or 'set'")
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -176,6 +176,68 @@ class Daemon:
         self.logger.debug("daemon initialization complete")
 
 
+    def add_get_handler(self, key, method):
+        """ Define a method that will be called for all GET requests for
+            the specified item. Refer to :func:`add_handlers` for additional
+            details.
+        """
+
+        try:
+            item = self.store[key]
+        except KeyError:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        self.rep._req_get_handlers[item.full_key] = method
+
+
+    def add_get_performer(self, key, method):
+        """ Define a method that will be called for all GET requests for
+            the specified item. Refer to :func:`mktl.Item.add_set_performer`
+            for additional details.
+        """
+
+        key = key.lower()
+        key = key.strip()
+
+        try:
+            existing = self.store._items[key]
+        except KeyError:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        if existing is None or existing.authoritative == False:
+            self.add_item(item.Item, key)
+            existing = self.store[key]
+
+        existing.add_get_performer(method)
+
+
+    def add_handler(self, key, request, method):
+        """ Define a method that will be called for either GET or SET
+            requests, determined by the *request* argument, which must be one
+            of 'get' or 'set'.
+
+            See :func:`mktl.Item.req_get` and
+            :func:`mktl.Item.req_set` for additional details; inspection of
+            the implementation for those methods is recommended to ensure all
+            the necessary actions are covered.
+        """
+
+        try:
+            item = self.store[key]
+        except KeyError:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        request = request.lower()
+        request = request.strip()
+
+        if request == 'get':
+            self.add_get_request(key, method)
+        elif request == 'set':
+            self.add_set_request(key, method)
+        else:
+            raise ValueError("request must be either 'get' or 'set'")
+
+
     def add_handlers(self, handlers):
         """ This method is intended to be a single call, accepting a sequence
             of triplets mapping external methods handling GET and SET
@@ -196,36 +258,7 @@ class Daemon:
 
         for triplet in handlers:
             key,request,method = triplet
-
-            key = key.lower()
-            key = key.strip()
-
-            # Allow this method to be called before placeholder Item instances
-            # have been established. The use of external handler methods
-            # implies the caller will not be instantiating custom Item
-            # subclasses; instantiating them now ensures any custom code is
-            # exclusive.
-
-            try:
-                existing = self.store._items[key]
-            except KeyError:
-                raise KeyError('this daemon does not contain ' + repr(key))
-
-            if existing is None or existing.authoritative == False:
-                self.add_item(item.Item, key)
-
-
-            request = request.lower()
-            request = request.strip()
-
-            full_key = self.store.name + '.' + key
-
-            if request == 'get':
-                self.rep._req_get_handlers[full_key] = method
-            elif request == 'set':
-                self.rep._req_set_handlers[full_key] = method
-            else:
-                raise ValueError("request must be either 'get' or 'set'")
+            self.add_handler(key, request, method)
 
 
     def add_item(self, item_class, key, **kwargs):
@@ -312,6 +345,41 @@ class Daemon:
                 existing = self.store[key]
 
             existing.add_performer(request, method)
+
+
+    def add_set_handler(self, key, method):
+        """ Define a method that will be called for all SET requests for
+            the specified item. Refer to :func:`add_handlers` for additional
+            details.
+        """
+
+        try:
+            item = self.store[key]
+        except KeyError:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        self.rep._req_set_handlers[item.full_key] = method
+
+
+    def add_set_performer(self, key, method):
+        """ Define a method that will be called for all SET requests for
+            the specified item. Refer to :func:`mktl.Item.add_set_performer`
+            for additional details.
+        """
+
+        key = key.lower()
+        key = key.strip()
+
+        try:
+            existing = self.store._items[key]
+        except KeyError:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        if existing is None or existing.authoritative == False:
+            self.add_item(item.Item, key)
+            existing = self.store[key]
+
+        existing.add_set_performer(method)
 
 
     def _begin_persistence(self):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -310,6 +310,34 @@ class Daemon:
                 created.register(callback)
 
 
+    def add_performer(self, key, request, method):
+        """ Define a method that will be called for either GET or SET
+            requests, determined by the *request* argument, which must be one
+            of 'get' or 'set'.
+
+            See :func:`mktl.Item.add_get_performer` and
+            :func:`mktl.Item.add_set_performer` for additional details.
+        """
+
+        # Allow this method to be called before placeholder Item instances
+        # have been established. The use of external performer methods,
+        # rather than overriding Item.perform_get() and Item.perform_set(),
+        # implies the caller will not be instantiating custom Item
+        # subclasses; instantiating them now ensures any custom code is
+        # exclusive.
+
+        try:
+            existing = self.store._items[key]
+        except KeyError:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        if existing is None or existing.authoritative == False:
+            self.add_item(item.Item, key)
+            existing = self.store[key]
+
+        existing.add_performer(request, method)
+
+
     def add_performers(self, performers):
         """ This method is intended to be a single call, accepting a sequence
             of triplets mapping external methods performing GET and SET
@@ -328,24 +356,7 @@ class Daemon:
 
         for triplet in performers:
             key,request,method = triplet
-
-            # Allow this method to be called before placeholder Item instances
-            # have been established. The use of external performer methods,
-            # rather than overriding Item.perform_get() and Item.perform_set(),
-            # implies the caller will not be instantiating custom Item
-            # subclasses; instantiating them now ensures any custom code is
-            # exclusive.
-
-            try:
-                existing = self.store._items[key]
-            except KeyError:
-                raise KeyError('this daemon does not contain ' + repr(key))
-
-            if existing is None or existing.authoritative == False:
-                self.add_item(item.Item, key)
-                existing = self.store[key]
-
-            existing.add_performer(request, method)
+            self.add_performer(key, request, method)
 
 
     def add_set_handler(self, key, method):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -230,11 +230,11 @@ class Daemon:
             requests, bypassing the usual handling chain involving
             :class:`mktl.Item` instances.
 
-            A triplet is the key for an item (including the store name), whether
+            A triplet is the key for an item (omitting the store name), whether
             this is a 'get' or a 'set' handler, and a valid reference to a
             method. For example::
 
-                ('maunakea.temperature', 'get', mkwc.get_temperature)
+                ('temperature', 'get', mkwc.get_temperature)
 
             See :func:`mktl.Item.req_get` and
             :func:`mktl.Item.req_set` for additional details; inspection of
@@ -243,18 +243,16 @@ class Daemon:
         """
 
         for triplet in handlers:
-            full_key,request,method = triplet
+            key,request,method = triplet
 
-            full_key = full_key.lower()
-            full_key = full_key.strip()
+            key = key.lower()
+            key = key.strip()
 
             # Allow this method to be called before placeholder Item instances
             # have been established. The use of external handler methods
             # implies the caller will not be instantiating custom Item
             # subclasses; instantiating them now ensures any custom code is
             # exclusive.
-
-            store,key = full_key.split('.', 1)
 
             try:
                 existing = self.store._items[key]
@@ -268,10 +266,12 @@ class Daemon:
             request = request.lower()
             request = request.strip()
 
+            full_key = self.store.name + '.' + key
+
             if request == 'get':
                 self.rep._req_get_handlers[full_key] = method
             elif request == 'set':
-                return self.add_set_performer(method)
+                self.rep._req_set_handlers[full_key] = method
             else:
                 raise ValueError("request must be either 'get' or 'set'")
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -249,7 +249,10 @@ class Daemon:
             # implies the caller will not be instantiating custom Item
             # subclasses.
 
-            existing = self.store._items[key]
+            try:
+                existing = self.store._items[key]
+            except KeyError:
+                raise KeyError('this daemon does not contain ' + repr(key))
 
             if existing is None or existing.authoritative == False:
                 self.add_item(item.Item, key)

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -243,6 +243,12 @@ class Daemon:
         for triplet in performers:
             key,request,method = triplet
 
+            # Allow this method to be called before placeolder Item instances
+            # have been established. The use of external performer methods,
+            # rather than overriding Item.perform_get() and Item.perform_set(),
+            # implies the caller will not be instantiating custom Item
+            # subclasses.
+
             existing = self.store._items[key]
 
             if existing is None or existing.authoritative == False:

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -464,6 +464,9 @@ class RequestServer(protocol.request.Server):
         protocol.request.Server.__init__(self, *args, **kwargs)
         self.daemon = daemon
 
+        self._req_get_methods = dict()
+        self._req_set_methods = dict()
+
 
     def req_config(self, request):
 
@@ -516,6 +519,13 @@ class RequestServer(protocol.request.Server):
 
     def req_get(self, request):
 
+        try:
+            getter = self._req_get_methods[request.target]
+        except KeyError:
+            pass
+        else:
+            return getter(request)
+
         store, key = request.target.split('.', 1)
 
         if store != self.daemon.store.name:
@@ -528,23 +538,12 @@ class RequestServer(protocol.request.Server):
         else:
             raise KeyError('this daemon does not contain ' + repr(key))
 
-        response = self.daemon.store[key].req_get(request)
-        return response
+        getter = self.daemon.store[key].req_get
+        self._req_get_methods[request.target] = getter
+        return getter(request)
 
 
     def req_set(self, request):
-
-        store, key = request.target.split('.', 1)
-
-        if store != self.daemon.store.name:
-            raise ValueError("this request is for %s, but this daemon is in %s" % (repr(store), repr(self.daemon.store.name)))
-
-        block = self.daemon.config[self.daemon.uuid]
-        items = block['items']
-        if key in items:
-            pass
-        else:
-            raise KeyError('this daemon does not contain ' + repr(key))
 
         ### This may be the right place to send a publish message indicating
         ### that a set request has been received. This would largely be a
@@ -555,8 +554,28 @@ class RequestServer(protocol.request.Server):
         ### This would allow a debug client to subscribe to all messages with
         ### a leading 'set:' topic.
 
-        response = self.daemon.store[key].req_set(request)
-        return response
+        try:
+            setter = self._req_set_methods[request.target]
+        except KeyError:
+            pass
+        else:
+            return setter(request)
+
+        store, key = request.target.split('.', 1)
+
+        if store != self.daemon.store.name:
+            raise ValueError("this request is for %s, but this daemon is in %s" % (repr(store), repr(self.daemon.store.name)))
+
+        block = self.daemon.config[self.daemon.uuid]
+        items = block['items']
+        if key in items:
+            pass
+        else:
+            raise KeyError('this daemon does not contain ' + repr(key))
+
+        setter = self.daemon.store[key].req_set
+        self._req_set_methods[request.target] = setter
+        return setter(request)
 
 
     def req_hash(self, request):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -224,6 +224,34 @@ class Daemon:
                 created.register(callback)
 
 
+    def add_performers(self, performers):
+        """ This method is intended to be a single call, accepting a sequence
+            of triplets mapping external methods performing GET and SET
+            requests back to the :class:`mktl.Item` instances receiving those
+            requests from this daemon.
+
+            A triplet is the key for an item (omitting the store name), whether
+            this is a 'get' or a 'set' performer, and a valid reference to a
+            method. For example::
+
+                ('temperature', 'get', mkwc.get_temperature)
+
+            See :func:`mktl.Item.add_get_performer` and
+            :func:`mktl.Item.add_set_performer` for additional details.
+        """
+
+        for triplet in performers:
+            key,request,method = triplet
+
+            existing = self.store._items[key]
+
+            if existing is None or existing.authoritative == False:
+                self.add_item(item.Item, key)
+                existing = self.store[key]
+
+            existing.add_performer(request, method)
+
+
     def _begin_persistence(self):
         """ Start the background process responsible for updating the
             persistent value cache.

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -179,8 +179,9 @@ class Daemon:
     def add_get_handler(self, key, method):
         """ Assign a method that will be called for all GET requests for
             the specified item. See :func:`mktl.Item.req_get` for additional
-            details; inspection of the implementation for that method is
-            recommended to ensure all the necessary actions are covered.
+            details on the expected behavior; inspection of the implementation
+            for that method is recommended to ensure all the necessary actions
+            are covered.
         """
 
         try:
@@ -218,9 +219,9 @@ class Daemon:
             of 'get' or 'set'.
 
             See :func:`mktl.Item.req_get` and
-            :func:`mktl.Item.req_set` for additional details; inspection of
-            the implementation for those methods is recommended to ensure all
-            the necessary actions are covered.
+            :func:`mktl.Item.req_set` for additional details on the expected
+            behavior; inspection of the implementation for those methods is
+            recommended to ensure all the necessary actions are covered.
         """
 
         try:
@@ -369,8 +370,9 @@ class Daemon:
     def add_set_handler(self, key, method):
         """ Assign a method that will be called for all SET requests for
             the specified item. See :func:`mktl.Item.req_set` for additional
-            details; inspection of the implementation for that method is
-            recommended to ensure all the necessary actions are covered.
+            details on the expected behavior; inspection of the implementation
+            for that method is recommended to ensure all the necessary actions
+            are covered.
         """
 
         try:

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -177,7 +177,7 @@ class Daemon:
 
 
     def add_get_handler(self, key, method):
-        """ Define a method that will be called for all GET requests for
+        """ Assign a method that will be called for all GET requests for
             the specified item. See :func:`mktl.Item.req_get` for additional
             details; inspection of the implementation for that method is
             recommended to ensure all the necessary actions are covered.
@@ -192,7 +192,7 @@ class Daemon:
 
 
     def add_get_performer(self, key, method):
-        """ Define a method that will be called for all GET requests for
+        """ Assign a method that will be called for all GET requests for
             the specified item. Refer to :func:`mktl.Item.add_set_performer`
             for additional details.
         """
@@ -213,7 +213,7 @@ class Daemon:
 
 
     def add_handler(self, key, request, method):
-        """ Define a method that will be called for either GET or SET
+        """ Assign a method that will be called for either GET or SET
             requests, determined by the *request* argument, which must be one
             of 'get' or 'set'.
 
@@ -318,7 +318,7 @@ class Daemon:
 
 
     def add_performer(self, key, request, method):
-        """ Define a method that will be called for either GET or SET
+        """ Assign a method that will be called for either GET or SET
             requests, determined by the *request* argument, which must be one
             of 'get' or 'set'.
 
@@ -367,7 +367,7 @@ class Daemon:
 
 
     def add_set_handler(self, key, method):
-        """ Define a method that will be called for all SET requests for
+        """ Assign a method that will be called for all SET requests for
             the specified item. See :func:`mktl.Item.req_set` for additional
             details; inspection of the implementation for that method is
             recommended to ensure all the necessary actions are covered.
@@ -382,7 +382,7 @@ class Daemon:
 
 
     def add_set_performer(self, key, method):
-        """ Define a method that will be called for all SET requests for
+        """ Assign a method that will be called for all SET requests for
             the specified item. Refer to :func:`mktl.Item.add_set_performer`
             for additional details.
         """

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -143,22 +143,22 @@ class Item:
         self.perform_get = self._perform_get_wrapper
 
 
-    def add_performer(self, type, method):
+    def add_performer(self, request, method):
         """ Define a method that will be called for either GET or SET requests,
-            determined by the *type* argument, which must be one of 'get' or
+            determined by the *request* argument, which must be one of 'get' or
             'set'. See :func:`add_get_performer` and :func:`add_set_performer`
             for additional information.
         """
 
-        type = type.lower()
-        type = type.strip()
+        request = request.lower()
+        request = request.strip()
 
-        if type == 'get':
+        if request == 'get':
             return self.add_get_performer(method)
-        elif type == 'set':
+        elif request == 'set':
             return self.add_set_performer(method)
         else:
-            raise ValueError("type must be either 'get' or 'set'")
+            raise ValueError("request must be either 'get' or 'set'")
 
 
     def add_set_performer(self, method):

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -131,7 +131,8 @@ class Item:
     def add_get_performer(self, method):
         """ Define a method that will be called for all GET requests for
             this item. This will replace the :func:`perform_get` method.
-            The performer method must accept no arguments.
+            The performer method must accept no arguments; refer to
+            :func:`perform_get` for additional details.
         """
 
         if callable(method):
@@ -165,7 +166,8 @@ class Item:
         """ Define a method that will be called for all SET requests for
             this item. This will replace the :func:`perform_set` method.
             The performer method must accept one argument, the 'unformatted'
-            Python native representation of the item value.
+            Python native representation of the item value; refer to
+            :func:`perform_set` for additional details.
         """
 
         if callable(method):
@@ -415,6 +417,14 @@ class Item:
             is returned it will be used as-is, otherwise the return value
             will be passed to :func:`to_payload` for encapsulation.
 
+            Calls to this method will be handled in a background thread with
+            no restrictions on how long a get request takes to process. There
+            are also no restrictions on concurrency, though ideally a get
+            request is trivial to execute; this method will be called
+            repeatedly if multiple requests arrive and one or more requests are
+            already in progress. Management of concurrent requests is left
+            entirely to the implementer.
+
             Returning None will not clear the currently known value, that will
             only occur if the returned Payload instance is assigned None as the
             'value'; this is not expected to be a common occurrence, but if a
@@ -443,6 +453,13 @@ class Item:
             a set request for this item. No return value is expected. Any
             subclass implementations should raise an exception in order to
             trigger an error response.
+
+            Calls to this method will be handled in a background thread with
+            no restrictions on how long a set request takes to process. There
+            are also no restrictions on concurrency; this method will be called
+            repeatedly if multiple requests arrive and one or more requests are
+            already in progress. Management of concurrent requests is left
+            entirely to the implementer.
 
             Any return value, though again none is expected, will be
             encapsulated via :func:`to_payload`, after the same fashion as

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -128,6 +128,55 @@ class Item:
             self.subscribe(prime=prime)
 
 
+    def add_get_performer(self, method):
+        """ Define a method that will be called for all GET requests for
+            this item. This will replace the :func:`perform_get` method.
+            The performer method must accept no arguments.
+        """
+
+        if callable(method):
+            pass
+        else:
+            raise TypeError('the performer method must be callable')
+
+        self._perform_get_external = method
+        self.perform_get = self._perform_get_wrapper
+
+
+    def add_performer(self, type, method):
+        """ Define a method that will be called for either GET or SET requests,
+            determined by the *type* argument, which must be one of 'get' or
+            'set'. See :func:`add_get_performer` and :func:`add_set_performer`
+            for additional information.
+        """
+
+        type = type.lower()
+        type = type.strip()
+
+        if type == 'get':
+            return self.add_get_performer(method)
+        elif type == 'set':
+            return self.add_set_performer(method)
+        else:
+            raise ValueError("type must be either 'get' or 'set'")
+
+
+    def add_set_performer(self, method):
+        """ Define a method that will be called for all SET requests for
+            this item. This will replace the :func:`perform_set` method.
+            The performer method must accept one argument, the 'unformatted'
+            Python native representation of the item value.
+        """
+
+        if callable(method):
+            pass
+        else:
+            raise TypeError('the performer method must be callable')
+
+        self._perform_set_external = method
+        self.perform_set = self._perform_set_wrapper
+
+
     def _cleanup(self):
         """ Shut down any background processing involved with this item.
             In the general case this is not required; :class:`Item` instances

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -62,6 +62,9 @@ class Item:
         self._update_thread = None
         self._updated = threading.Event()
 
+        self._perform_get_external = None
+        self._perform_set_external = None
+
         # An Item is a singleton in practice; enforce that constraint.
 
         try:
@@ -378,6 +381,14 @@ class Item:
         return payload
 
 
+    def _perform_get_wrapper(self):
+        """ The only purpose of this wrapper method is to strip the 'self'
+            argument from a call to an external method.
+        """
+
+        return self._perform_get_external()
+
+
     def perform_set(self, new_value):
         """ Implement any custom behavior that should occur as a result of
             a set request for this item. No return value is expected. Any
@@ -395,6 +406,14 @@ class Item:
         # is published.
 
         pass
+
+
+    def _perform_set_wrapper(self, new_value):
+        """ The only purpose of this wrapper method is to strip the 'self'
+            argument from a call to an external method.
+        """
+
+        return self._perform_set_external(new_value)
 
 
     def poll(self, period):

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -62,9 +62,6 @@ class Item:
         self._update_thread = None
         self._updated = threading.Event()
 
-        self._perform_get_external = None
-        self._perform_set_external = None
-
         # An Item is a singleton in practice; enforce that constraint.
 
         try:

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -126,10 +126,12 @@ class Item:
 
 
     def add_get_performer(self, method):
-        """ Assign a method that will be called for all GET requests for
-            this item. This will replace the :func:`perform_get` method.
-            The performer method must accept no arguments; refer to
-            :func:`perform_get` for additional details.
+        """ Assign a method that will be called for all GET requests for this
+            item. This will replace the :func:`perform_get` method in situations
+            where the caller does not want to establish custom subclasses and
+            override :func:`perform_get` directly. The performer method must
+            accept no arguments; refer to :func:`perform_get` for additional
+            details on the expected behavior.
         """
 
         if callable(method):
@@ -159,11 +161,13 @@ class Item:
 
 
     def add_set_performer(self, method):
-        """ Assign a method that will be called for all SET requests for
-            this item. This will replace the :func:`perform_set` method.
-            The performer method must accept one argument, the 'unformatted'
-            Python native representation of the item value; refer to
-            :func:`perform_set` for additional details.
+        """ Assign a method that will be called for all SET requests for this
+            item. This will replace the :func:`perform_set` method in situations
+            where the caller does not want to establish custom subclasses and
+            override :func:`perform_set` directly. The performer method must
+            accept one argument, the 'unformatted' Python-native representation
+            of the item value; refer to :func:`perform_set` for additional
+            details on the expected behavior.
         """
 
         if callable(method):

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -140,8 +140,7 @@ class Item:
         else:
             raise TypeError('the performer method must be callable')
 
-        self._perform_get_external = method
-        self.perform_get = self._perform_get_wrapper
+        self.perform_get = method
 
 
     def add_performer(self, request, method):
@@ -175,8 +174,7 @@ class Item:
         else:
             raise TypeError('the performer method must be callable')
 
-        self._perform_set_external = method
-        self.perform_set = self._perform_set_wrapper
+        self.perform_set = method
 
 
     def _cleanup(self):
@@ -452,14 +450,6 @@ class Item:
         return payload
 
 
-    def _perform_get_wrapper(self):
-        """ The only purpose of this wrapper method is to strip the 'self'
-            argument from a call to an external method.
-        """
-
-        return self._perform_get_external()
-
-
     def perform_set(self, new_value):
         """ Implement any custom behavior that should occur as a result of
             a set request for this item. No return value is expected. Any
@@ -484,14 +474,6 @@ class Item:
         # is published.
 
         pass
-
-
-    def _perform_set_wrapper(self, new_value):
-        """ The only purpose of this wrapper method is to strip the 'self'
-            argument from a call to an external method.
-        """
-
-        return self._perform_set_external(new_value)
 
 
     def poll(self, period):

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -126,7 +126,7 @@ class Item:
 
 
     def add_get_performer(self, method):
-        """ Define a method that will be called for all GET requests for
+        """ Assign a method that will be called for all GET requests for
             this item. This will replace the :func:`perform_get` method.
             The performer method must accept no arguments; refer to
             :func:`perform_get` for additional details.
@@ -141,7 +141,7 @@ class Item:
 
 
     def add_performer(self, request, method):
-        """ Define a method that will be called for either GET or SET requests,
+        """ Assign a method that will be called for either GET or SET requests,
             determined by the *request* argument, which must be one of 'get' or
             'set'. See :func:`add_get_performer` and :func:`add_set_performer`
             for additional information.
@@ -159,7 +159,7 @@ class Item:
 
 
     def add_set_performer(self, method):
-        """ Define a method that will be called for all SET requests for
+        """ Assign a method that will be called for all SET requests for
             this item. This will replace the :func:`perform_set` method.
             The performer method must accept one argument, the 'unformatted'
             Python native representation of the item value; refer to


### PR DESCRIPTION
This pull requests enables the developer to specify how GET and SET requests will be handled on a per-item basis without requiring the use of custom subclasses of mktl.Item.