### PR TITLE
Code of conduct

### DIFF
--- a/doc/code_of_conduct.rst
+++ b/doc/code_of_conduct.rst
@@ -51,6 +51,11 @@ This code of conduct applies to all mKTL community situations online and
 offline, including mailing lists, forums, social media, conferences, meetings,
 associated social events, and one-to-one interactions.
 
+Project maintainers will decide as a group on how to proceed in response to
+any reports. Resulting consequences can include revocation of contributor
+and/or maintainer status; additional consequences may occur at the discretion
+of the reported person's current employer.
+
 ----
 
 This document is a modified version of the `PypeIt Code of Conduct

--- a/doc/code_of_conduct.rst
+++ b/doc/code_of_conduct.rst
@@ -1,0 +1,63 @@
+
+Code of conduct
+===============
+
+The community of participants in the open-source mKTL project is made up of
+members from around the globe with a diverse set of skills, personalities, and
+experiences. It is through these differences that our community experiences
+success and continued growth. We expect everyone in our community to follow
+these guidelines when interacting with others both inside and outside of our
+community. Our goal is to maintain a community that is positive, inclusive,
+successful, and growing.
+
+As members of the community,
+
+- We pledge to treat all people with respect and provide a harassment- and
+  bullying-free environment, regardless of sex, sexual orientation and/or gender
+  identity, disability, physical appearance, body size, race, nationality,
+  ethnicity, and religion. In particular, sexual language and imagery, sexist,
+  racist, or otherwise exclusionary jokes are not appropriate.
+
+- We pledge to respect the work of others by recognizing acknowledgment/citation
+  requests of original authors. As authors, we pledge to be explicit about how
+  we want our own work to be cited or acknowledged.
+
+- We pledge to welcome those interested in joining the community, and realize
+  that including people with a variety of opinions and backgrounds will only
+  serve to enrich our community. In particular, discussions relating to
+  pros/cons of various technologies, programming languages, and so on are
+  welcome, but these should be done with respect, taking proactive measures to
+  ensure that all participants are heard and feel confident that they can freely
+  express their opinions.
+
+- We pledge to welcome questions and answer them respectfully, paying particular
+  attention to those new to the community. We pledge to provide respectful
+  criticisms and feedback in forums, especially in discussion threads resulting
+  from code contributions.
+
+- We pledge to be conscientious of the perceptions of the wider community and to
+  respond to criticism respectfully. We will strive to model behaviors that
+  encourage productive debate and disagreement, both within our community and
+  where we are criticized. We will treat those outside our community with the
+  same respect as people within our community.
+
+- We pledge to help the entire community follow the code of conduct and to not
+  remain silent when we see or experience violations. Reported violations will
+  be acted upon in a timely manner. Code-of-conduct violations can be reported
+  by contacting any mKTL maintainer. All communications regarding such
+  violations will be treated with the strictest confidence.
+
+This code of conduct applies to all mKTL community situations online and
+offline, including mailing lists, forums, social media, conferences, meetings,
+associated social events, and one-to-one interactions.
+
+----
+
+This document is a modified version of the `PypeIt Code of Conduct
+<https://pypeit.readthedocs.io/en/stable/codeconduct.html>`_, which is
+itself a modified version of the `Astropy Code of Conduct
+<https://www.astropy.org/code_of_conduct.html>`_, licensed under a `Creative
+Commons Attribution 4.0 International License
+<https://creativecommons.org/licenses/by/4.0/>`__, of which parts were
+originally adapted from the `PSF Code of Conduct
+<https://www.python.org/psf/conduct/>`_.

--- a/doc/code_of_conduct.rst
+++ b/doc/code_of_conduct.rst
@@ -59,5 +59,6 @@ itself a modified version of the `Astropy Code of Conduct
 <https://www.astropy.org/code_of_conduct.html>`_, licensed under a `Creative
 Commons Attribution 4.0 International License
 <https://creativecommons.org/licenses/by/4.0/>`__, of which parts were
-originally adapted from the `PSF Code of Conduct
-<https://www.python.org/psf/conduct/>`_.
+originally adapted from the `Python Software Foundation Code of Conduct
+<https://www.python.org/psf/conduct/>`_ and the
+`NumFOCUS Code of Conduct <https://numfocus.org/code-of-conduct>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,6 +35,7 @@ be expert mKTL maintainers in order to successfully develop an application.
    configuration
    protocol
    protocol_interface
+   code_of_conduct
    glossary
 
 Indices and tables


### PR DESCRIPTION
This pull request adds a code of conduct to the official mKTL documentation. The contents are largely copied from the code of conduct for the PypeIt project.