### PR TITLE
Align publish, request, and response multipart components

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -63,6 +63,13 @@ For both ends of the request/response exchange, the message parts are:
   * - *Field*
     - *Data type*
 
+  * - **target**
+    - The target for this request/response, if any. Not all requests have a
+      target; responses don't need to specify it, since it is the identification
+      number that ties a response to its request. If a target is specified it
+      is a store or a key, depending on the request; this field will be an empty
+      byte sequence if the target is not specified.
+
   * - **version**
     - A single ASCII character indicating the mKTL protocol version number.
       The initial release of the mKTL protocol uses the version character 'a'.
@@ -81,13 +88,6 @@ For both ends of the request/response exchange, the message parts are:
     - The message type. This is a short string of characters that identifies
       what type of request, or reponse, this message represents. It is one
       of the values described in the ref:`message_types` section below.
-
-  * - **target**
-    - The target for this request/response, if any. Not all requests have a
-      target; responses don't need to specify it, since it is the identification
-      number that ties a response to its request. If a target is specified it
-      is a store or a key, depending on the request; this field will be an empty
-      byte sequence if the target is not specified.
 
   * - **payload**
     - The message payload. This is the JSON representation of any additional
@@ -138,24 +138,24 @@ like, in this case handling the exchange as a synchronous request::
 Here is a representation of what the on-the-wire messages might look like
 for the simple exchange outlined above::
 
+	b'kpfguide.LASTFILENAME'
 	b'a'
 	b'00000023'
 	b'GET'
-	b'kpfguide.LASTFILENAME'
 	b''
 	b''
 
+	b''
 	b'a'
 	b'00000023'
 	b'ACK'
 	b''
 	b''
-	b''
 
+	b''
 	b'a'
 	b'00000023'
 	b'REP'
-	b''
 	b'{"value": /sdata1701/kpf1/2025-06-23/image_672.fits', "time": 234.23}'
 	b''
 
@@ -357,8 +357,8 @@ Publish/subscribe
 -----------------
 
 The second socket type implements a publish/subscribe socket pattern. The
-desired functionality in mKTL is a neat match for the PUB/SUB socket pattern
-offered by ZeroMQ:
+desired functionality in mKTL is an excellent match for the PUB/SUB socket
+pattern offered by ZeroMQ:
 
 	* SUB clients subscribe to one or more topics from
 	  a given PUB socket, or can subscribe to all topics
@@ -373,41 +373,12 @@ offered by ZeroMQ:
 	  subscribed to those specific topics, the broadcasts
 	  are never sent to the client.
 
-The formatting of the PUB message is very similar to what is described
+The formatting of the PUB message is exactly the same as what is described
 above for the :ref:`request/response multipart message format <request>`.
-Some fields are not necessary for the PUB variant, and in order for the
-topic matching to work the topic must be the first component of a multipart
-message. The fields are as follows:
-
-.. list-table::
-
-  * - *Field*
-    - *Data type*
-
-  * - **topic**
-    - For a typical broadcast the topic will be the full key for a single
-      mKTL item. This is similar to the 'target' field in a
-      :ref:`request/response message <request>`. For all mKTL addressing
-      the topic appends a trailing '.' in order to prevent unwanted substring
-      matching between similarly
-      named keys. Likewise, because of the ZeroMQ behavior around leading
-      substrings, any expanded use of mKTL PUB/SUB behavior will use a
-      leading prefix to distinguish it from other message types. For example,
-      broadcasting all SET requests with a leading 'set:' prefix, or
-      broadcasting a bundle of related mKTL items with a leading 'bundle:'
-      prefix.
-
-  * - **version**
-    - A single ASCII character indicating the mKTL protocol version number.
-      The initial release of the mKTL protocol uses the version character 'a'.
-
-  * - **payload**
-    - The message payload, with exactly the same contents as
-      :ref:`described above <message_payload>`.
-
-  * - **bulk**
-    - A bulk byte sequence, with exactly the same contents as the
-      :ref:`request/response message <request>`.
+Some fields, such as the identifier, are not necessary for the PUB variant
+and will always be empty. The PUB/SUB message structure, where the topic
+must be the first field in the multipart message, motivates having that
+field be the first part for the universal mKTL message structure.
 
 
 .. _discovery:
@@ -420,7 +391,7 @@ are you allowed to have multiple listeners on the same port, but they will all
 respond to an incoming broadcast message. Some care thus needs to be taken to
 make sure these responses do not lend themselves to a denial of service attack.
 Regardless, this feature allows every daemon to create a listener on the same
-port, which greatly simplfies periodic discovery.
+port, which simplifies periodic discovery.
 
 The discovery of daemons is a two-part process; rather than ask every daemon
 to cache the configuration for every other daemon on its local network, the

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -54,9 +54,10 @@ in any order, in any direction.
 
 The request/response interaction between the client and daemon is a multipart
 message, where each part is required and has specific meaning. The reference
-implementation provides a :class:`mktl.protocol.Message` class to minimize
-the amount of code that has to be aware about the on-the-wire message structure.
-For both ends of the request/response exchange, the message parts are:
+implementation provides a :class:`mktl.protocol.message.Message` class to
+minimize the amount of code that has to be aware about the on-the-wire message
+structure. For both ends of the request/response exchange, the message parts
+are:
 
 .. list-table::
 
@@ -87,7 +88,7 @@ For both ends of the request/response exchange, the message parts are:
   * - **type**
     - The message type. This is a short string of characters that identifies
       what type of request, or response, this message represents. It is one
-      of the values described in the ref:`message_types` section below.
+      of the values described in the :ref:`message_types` section below.
 
   * - **payload**
     - The message payload. This is the JSON representation of any additional

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -86,7 +86,7 @@ For both ends of the request/response exchange, the message parts are:
 
   * - **type**
     - The message type. This is a short string of characters that identifies
-      what type of request, or reponse, this message represents. It is one
+      what type of request, or response, this message represents. It is one
       of the values described in the ref:`message_types` section below.
 
   * - **payload**

--- a/doc/protocol_interface.rst
+++ b/doc/protocol_interface.rst
@@ -24,9 +24,6 @@ Message classes
 .. autoclass:: Message
    :members:
 
-.. autoclass:: Broadcast
-   :members:
-
 .. autoclass:: Request
    :members:
 

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -53,6 +53,9 @@ def main():
             request = mktl.protocol.message.Request('HASH')
             try:
                 payload = mktl.protocol.request.send(address, port, request)
+            except TimeoutError:
+                logger.warning("HASH request from %s:%d timed out" % (address, port))
+                continue
             except:
                 logger.warning("HASH request from %s:%d failed" % (address, port))
                 continue

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -459,7 +459,7 @@ class Item:
 
         if changed == True or repeat == True:
             key = self.full_key
-            message = protocol.message.Broadcast('PUB', key, payload)
+            message = protocol.message.Message('PUB', key, payload)
 
             # One could bypass the normal broadcast handling internally
             # within a daemon by putting the message in self._update_queue

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -458,13 +458,13 @@ def from_parts(parts):
         payload = parts[4]
         bulk = parts[5]
 
-        if target and target[-1] == b'.':
+        target = target.decode()
+
+        if target[-1] == '.':
             target = target[:-1]
 
-        if target == b'':
+        if target == '':
             target = None
-        else:
-            target = target.decode()
 
         message_type = message_type.decode()
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -75,7 +75,7 @@ class Message:
         :ivar timestamp: A UNIX epoch timestamp for the message send time.
     """
 
-    valid_types = set(('ACK', 'CONFIG', 'GET', 'HASH', 'PUB', 'REP'))
+    valid_types = set(('ACK', 'CONFIG', 'GET', 'HASH', 'PUB', 'REP', 'SET'))
 
     def __init__(self, type, target=None, payload=None, id=None):
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -75,7 +75,7 @@ class Message:
         :ivar timestamp: A UNIX epoch timestamp for the message send time.
     """
 
-    valid_types = set(('ACK', 'REP'))
+    valid_types = set(('ACK', 'PUB', 'REP'))
 
     def __init__(self, type, target=None, payload=None, id=None):
 
@@ -99,13 +99,13 @@ class Message:
 
 
     def __iter__(self):
-        self._finalize()
-        return iter(self._parts)
+        parts = self._finalize()
+        return iter(parts)
 
 
     def __repr__(self):
-        self._finalize()
-        return repr(self._parts)
+        parts = self._finalize()
+        return repr(parts)
 
 
     def _finalize(self):
@@ -123,18 +123,21 @@ class Message:
         target = self.target
         payload = self.payload
 
-        # It is legal to create a Message with None as the id-- this happens
-        # all the time when a Message is used as a container-- but trying to
-        # send such a message is not permitted.
+        # All requests and responses should have a locally unique identifier,
+        # but publish messages do not, and it is not an error for a Message
+        # instance to be used as a container and not have an identifier--
+        # but putting one on the wire would ideally be prevented. There used
+        # to be a guard against that here, but that had to be removed for the
+        # realignment of the request/response and publish message structure.
 
         if id is None:
-            raise RuntimeError('messages must have an id to be put on the wire')
-
-        try:
-            id.decode
-        except AttributeError:
-            id = '%08x' % (id)
-            id = id.encode()
+            id = b''
+        else:
+            try:
+                id.decode
+            except AttributeError:
+                id = '%08x' % (id)
+                id = id.encode()
 
         type = type.encode()
 
@@ -147,6 +150,11 @@ class Message:
                 # Assume it is already bytes.
                 pass
 
+            # Use a trailing dot to prevent leading substring matches from
+            # matching the wrong key.
+
+            target = target + b'.'
+
         if payload is None or payload == '':
             bulk = b''
             payload = b''
@@ -157,9 +165,9 @@ class Message:
             payload = payload.encapsulate()
 
         if self.prefix:
-            parts = self.prefix + (version, id, type, target, payload, bulk)
+            parts = self.prefix + (target, version, id, type, payload, bulk)
         else:
-            parts = (version, id, type, target, payload, bulk)
+            parts = (target, version, id, type, payload, bulk)
 
         self._parts = parts
 
@@ -196,46 +204,6 @@ class Message:
 
 
 # end of class Message
-
-
-
-class Broadcast(Message):
-    """ A :class:`Broadcast` is a minor variant of a :class:`Message`,
-        with a change to format the multipart tuple in a PUB/SUB specific
-        fashion.
-    """
-
-    valid_types = set(('PUB',))
-
-    def _finalize(self):
-
-        if self._parts:
-            # Once finalized, always finalized.
-            return
-
-        target = self.target
-        payload = self.payload
-
-        # The PUB/SUB topic has a trailing dot to prevent leading
-        # substring matches from picking up extra keys.
-
-        target = target + '.'
-        target = target.encode()
-
-        if payload is None or payload == '':
-            bulk = b''
-            payload = b''
-        else:
-            bulk = payload.bulk
-            if bulk is None:
-                bulk = b''
-            payload = payload.encapsulate()
-
-        # The prefix is ignored for broadcast messages; it should not be set.
-        self._parts = (target, version, payload, bulk)
-
-
-# end of class Broadcast
 
 
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -427,6 +427,65 @@ class Payload:
 # end of class Payload
 
 
+
+def from_parts(parts):
+    """ Translate a multipart message into a :class:`Message` instance.
+        Any translation errors, such as a version mismatch, will be
+        encpasulated in the returned Message.
+
+        This is the inverse of :func:`Message._finalize`.
+    """
+
+    error = None
+
+    try:
+        target = parts[0]
+        message_version = parts[1]
+        message_id = parts[2]
+    except IndexError:
+        message_id = None
+        error = dict()
+        error['type'] = 'RuntimeError'
+        error['text'] = "%d parts found, not enough to reconstruct a message" % (len(parts))
+
+    if not error and message_version != version:
+        error = dict()
+        error['type'] = 'RuntimeError'
+        error['text'] = "message is mKTL protocol %s, recipient expects %s" % (repr(message_version), repr(version))
+
+    if not error:
+        message_type = parts[3]
+        payload = parts[4]
+        bulk = parts[5]
+
+        if target and target[-1] == b'.':
+            target = target[:-1]
+
+    if error:
+        payload = message.Payload(None, error=error)
+        payload = payload.encapsulate()
+        message_type = 'REP'
+        target = '???'
+        bulk = None
+
+    if bulk == b'':
+        bulk = None
+
+    if payload == b'':
+        payload = None
+    else:
+        payload = json.loads(payload)
+        try:
+            payload = Payload(**payload, bulk=bulk)
+        except TypeError:
+            # Weird stuff in the payload. Don't fail on the conversion,
+            # allow it to pass, assuming the users know what they're doing.
+            pass
+
+    message = Message(message_type, target, payload, id=message_id)
+    return message
+
+
 _id_min = 0
 _id_max = 0xFFFFFFFF
 _id_lock = threading.Lock()

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -75,7 +75,7 @@ class Message:
         :ivar timestamp: A UNIX epoch timestamp for the message send time.
     """
 
-    valid_types = set(('ACK', 'PUB', 'REP'))
+    valid_types = set(('ACK', 'CONFIG', 'GET', 'HASH', 'PUB', 'REP'))
 
     def __init__(self, type, target=None, payload=None, id=None):
 
@@ -460,7 +460,7 @@ def from_parts(parts, throw=False):
 
         error = dict()
         error['type'] = 'RuntimeError'
-        error['text'] = "message is mKTL protocol %s, recipient expects %s" % (repr(message_version), repr(version))
+        error['text'] = error_text
 
     if not error:
         message_type = parts[3]

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -460,11 +460,10 @@ def from_parts(parts):
 
         target = target.decode()
 
-        if target[-1] == '.':
-            target = target[:-1]
-
-        if target == '':
+        if target == '' or target == '.':
             target = None
+        elif target[-1] == '.':
+            target = target[:-1]
 
         message_type = message_type.decode()
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -82,7 +82,7 @@ class Message:
         if type in self.valid_types:
             pass
         else:
-            raise ValueError('invalid request type: ' + type)
+            raise ValueError('invalid request type: ' + repr(type))
 
         # There are some message types where the id is allowed to be None;
         # for example, publish messages do not have or need an identification
@@ -99,13 +99,13 @@ class Message:
 
 
     def __iter__(self):
-        parts = self._finalize()
-        return iter(parts)
+        self._finalize()
+        return iter(self._parts)
 
 
     def __repr__(self):
-        parts = self._finalize()
-        return repr(parts)
+        self._finalize()
+        return repr(self._parts)
 
 
     def _finalize(self):
@@ -461,12 +461,22 @@ def from_parts(parts):
         if target and target[-1] == b'.':
             target = target[:-1]
 
+        if target == b'':
+            target = None
+        else:
+            target = target.decode()
+
+        message_type = message_type.decode()
+
     if error:
         payload = message.Payload(None, error=error)
         payload = payload.encapsulate()
         message_type = 'REP'
         target = '???'
         bulk = None
+
+    if message_id == b'':
+        message_id = None
 
     if bulk == b'':
         bulk = None

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -428,7 +428,7 @@ class Payload:
 
 
 
-def from_parts(parts):
+def from_parts(parts, throw=False):
     """ Translate a multipart message into a :class:`Message` instance.
         Any translation errors, such as a version mismatch, will be
         encpasulated in the returned Message.
@@ -444,11 +444,20 @@ def from_parts(parts):
         message_id = parts[2]
     except IndexError:
         message_id = None
+        error_text = "%d parts found, not enough to reconstruct a message" % (len(parts))
+        if throw:
+            raise RuntimeError(error_text)
+
         error = dict()
         error['type'] = 'RuntimeError'
-        error['text'] = "%d parts found, not enough to reconstruct a message" % (len(parts))
+        error['text'] = error_text
 
     if not error and message_version != version:
+        error_text = "message is mKTL protocol %s, recipient expects %s" % (repr(message_version), repr(version))
+
+        if throw:
+            raise RuntimeError(error_text)
+
         error = dict()
         error['type'] = 'RuntimeError'
         error['text'] = "message is mKTL protocol %s, recipient expects %s" % (repr(message_version), repr(version))

--- a/src/mktl/protocol/publish.py
+++ b/src/mktl/protocol/publish.py
@@ -56,7 +56,7 @@ class Client:
         self.thread.start()
 
 
-    def propagate(self, topic, message):
+    def propagate(self, message):
         """ Invoke any/all callbacks registered via :func:`register` for
             a newly arrived message.
         """
@@ -94,6 +94,8 @@ class Client:
         # Handle the case where a callback is registered for a specific topic.
         # If there are no topic-specific callbacks, no further processing is
         # required.
+
+        topic = message.target
 
         if self.callback_specific:
             pass
@@ -152,8 +154,6 @@ class Client:
         else:
             topic = str(topic)
             topic = topic.strip()
-            topic = topic + '.'
-            topic = topic.encode()
 
             try:
                 callbacks = self.callback_specific[topic]
@@ -162,6 +162,9 @@ class Client:
                 self.callback_specific[topic] = callbacks
 
             callbacks.append(reference)
+
+            topic = topic + '.'
+            topic = topic.encode()
             self.subscribe(topic)
 
 
@@ -192,33 +195,8 @@ class Client:
             ### floor.
             return
 
-        topic = parts[0]
-        their_version = parts[1]
-
-        if their_version != message.version:
-            ### Maybe we should occasionally log a version mismatch.
-            ### For now it's being dropped on the floor.
-            return
-
-        payload = parts[2]
-        bulk = parts[3]
-
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = message.Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        broadcast = message.Broadcast('PUB', topic, payload)
-        self.propagate(topic, broadcast)
+        broadcast = message.from_parts(parts)
+        self.propagate(broadcast)
 
 
     def _sub_incoming(self):
@@ -331,7 +309,7 @@ class Server:
 
 
     def publish(self, message):
-        """ A *message* is a :class:`mktl.protocol.message.Broadcast` instance
+        """ A *message* is a :class:`mktl.protocol.message.Message` instance
             intended for broadcast to any/all subscribers.
         """
 

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -79,57 +79,21 @@ class Client:
             any further handling by the original caller.
         """
 
-        their_version = parts[0]
-
-        if their_version == message.version:
-            response_type = parts[2]
-            target = parts[3]
-            payload = parts[4]
-            bulk = parts[5]
-        else:
-            error = dict()
-            error['type'] = 'RuntimeError'
-            error['text'] = "message is mKTL protocol %s, recipient expects %s" % (repr(their_version), repr(message.version))
-            payload = message.Payload(None, error=error)
-            payload = payload.encapsulate()
-            response_type = 'REP'
-            target = '???'
-            bulk = None
-
-        # This could still blow up if the version doesn't match-- the id may
-        # be in a different message part-- but we have to try, otherwise
-        # there's no way to pass the error back to the original caller.
-
-        response_id = parts[1]
+        response = message.from_parts(parts)
 
         try:
-            pending = self.pending[response_id]
+            pending = self.pending[response.id]
         except KeyError:
             # The original caller's request is gone, no further processing
             # is possible.
             return
 
-        if response_type == b'ACK':
+        if response.type == 'ACK':
             pending._complete_ack()
             return
 
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = message.Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        response = message.Message('REP', target, payload, response_id)
         pending._complete(response)
-        del self.pending[response_id]
+        del self.pending[response.id]
 
 
     def _req_outgoing(self):

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -101,10 +101,10 @@ class Client:
         """
 
         self.request_receive.recv(flags=zmq.NOBLOCK)
-        message = self.requests.get(block=False)
+        request = self.requests.get(block=False)
 
-        parts = tuple(message)
-        self.pending[message.id] = message
+        parts = tuple(request)
+        self.pending[request.id] = request
 
         # A lock around the ZeroMQ socket is necessary in a multithreaded
         # application; otherwise, if two different threads both invoke
@@ -148,11 +148,11 @@ class Client:
                     self._rep_incoming(parts)
 
 
-    def send(self, message):
-        """ A *message* is a fully populated
+    def send(self, request):
+        """ A *request* is a fully populated
             :class:`mktl.protocol.message.Request` instance,
             which normalizes the arguments that will be sent via this method
-            as a multi-part message. The message instance will also be used for
+            as a multi-part message. The request instance will also be used for
             notification of any/all responses from the remote end; this method
             will block while waiting for the ACK request, but will never block
             waiting for the full response; the caller is free to decide whether
@@ -160,14 +160,14 @@ class Client:
             :class:`mktl.protocol.message.Request` instance.
         """
 
-        self.requests.put(message)
+        self.requests.put(request)
         self.request_signal.send(b'')
 
-        ack = message.wait_ack(self.timeout)
+        ack = request.wait_ack(self.timeout)
 
         if ack == False:
             error = '%s @ %s:%d: no response received in %.2f sec'
-            args = (message.type, self.address, self.port, self.timeout)
+            args = (request.type, self.address, self.port, self.timeout)
             error = error % args
             raise TimeoutError(error)
 
@@ -350,8 +350,8 @@ class Server:
         ### exceptions are passed back to the originator of the request.
         ### Presumably that means calling something like _req_incoming().
 
-        request = message.from_parts(parts, throw=True)
-        request.prefix = (ident,)
+        request = message.from_parts(parts[1:], throw=True)
+        request.prefix = (parts[0],)
         payload = None
         error = None
 
@@ -377,7 +377,7 @@ class Server:
             elif payload.error is None:
                 payload.error = error
 
-        response = message.Message('REP', target, payload, req_id)
+        response = message.Message('REP', request.target, payload, request.id)
         response.prefix = request.prefix
 
         self.send(response)

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -350,39 +350,7 @@ class Server:
         ### exceptions are passed back to the originator of the request.
         ### Presumably that means calling something like _req_incoming().
 
-        ident = parts[0]
-        target = parts[1]
-        their_version = parts[2]
-
-        if their_version != message.version:
-            raise ValueError("message is mKTL protocol %s, recipient is %s" % (repr(their_version), repr(message.version)))
-
-        req_id = parts[3]
-        req_type = parts[4]
-        payload = parts[5]
-        bulk = parts[6]
-
-        req_type = req_type.decode()
-        target = target.decode()
-
-        if target[-1] == '.':
-            target = target[:-1]
-
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = message.Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        request = message.Request(req_type, target, payload, req_id)
+        request = message.from_parts(parts, throw=True)
         request.prefix = (ident,)
         payload = None
         error = None

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -387,19 +387,22 @@ class Server:
         ### Presumably that means calling something like _req_incoming().
 
         ident = parts[0]
-        their_version = parts[1]
+        target = parts[1]
+        their_version = parts[2]
 
         if their_version != message.version:
             raise ValueError("message is mKTL protocol %s, recipient is %s" % (repr(their_version), repr(message.version)))
 
-        req_id = parts[2]
-        req_type = parts[3]
-        target = parts[4]
+        req_id = parts[3]
+        req_type = parts[4]
         payload = parts[5]
         bulk = parts[6]
 
         req_type = req_type.decode()
         target = target.decode()
+
+        if target[-1] == '.':
+            target = target[:-1]
 
         if bulk == b'':
             bulk = None

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -350,6 +350,9 @@ class Server:
         ### exceptions are passed back to the originator of the request.
         ### Presumably that means calling something like _req_incoming().
 
+        ### As it currently stands, any exceptions occurring here are being
+        ### silently eaten by the thread pool executing this method.
+
         request = message.from_parts(parts[1:], throw=True)
         request.prefix = (parts[0],)
         payload = None

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -455,6 +455,12 @@ def send(address, port, request):
     connection.send(request)
     request.wait()
 
+    if request.response is None:
+        error = '%s @ %s:%d: no response received'
+        args = (request.type, address, port)
+        error = error % args
+        raise TimeoutError(error)
+
     payload = request.response.payload
     return payload
 

--- a/tests/protocol/test_message.py
+++ b/tests/protocol/test_message.py
@@ -1,0 +1,24 @@
+import json
+import mktl
+
+
+def test_message_translation():
+
+    payload = mktl.protocol.message.Payload(True)
+    message = mktl.protocol.message.Message('PUB', payload=payload)
+    parts = tuple(message)
+
+    translated = mktl.protocol.message.from_parts(parts)
+
+    assert message.id == translated.id
+    assert message.type == translated.type
+    assert message.prefix == translated.prefix
+    assert message.target == translated.target
+
+    assert round(message.timestamp, 4) == round(translated.timestamp, 4)
+
+    assert message.payload.value == translated.payload.value
+    assert message.payload.time == translated.payload.time
+
+
+# vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 autoindent:

--- a/tests/protocol/test_message.py
+++ b/tests/protocol/test_message.py
@@ -15,7 +15,10 @@ def test_message_translation():
     assert message.prefix == translated.prefix
     assert message.target == translated.target
 
-    assert round(message.timestamp, 4) == round(translated.timestamp, 4)
+    # The message.timestamp is created anew for every Message instance,
+    # it is not part of what is encapsulated for transmission.
+
+    assert message.timestamp != translated.timestamp
 
     assert message.payload.value == translated.payload.value
     assert message.payload.time == translated.payload.time


### PR DESCRIPTION
This pull request modifies the on-the-wire ordering of the multipart message components such that all requests, responses, and publications are using exactly the same structure. As part of this change, reconstruction of messages from multipart tuples is now handled in a single method rather than in multiple places in the code base.

The main change to highlight is the elimination of the special message.Broadcast class. This required some broadening of the base message.Message class; it was further broadened when message.from_parts() was established to provide a single point-of-entry to translate any multipart message back into a message.Message instance.

The Message._finalize() method shows the key change for the ordering, where the target/topic field is now first among multiparts in order for the PUB/SUB case to continue working as expected.