### PR TITLE
Optional bulk

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -102,8 +102,8 @@ are:
     - A bulk byte sequence, typically a component of the payload. This is to
       allow the transmission of information like image data, where the bulk
       bytes represent the image buffer, and the JSON payload describes how
-      to interpret the buffer. This field will be an empty byte sequence if
-      there is no bulk component.
+      to interpret the buffer. This field will be omitted entirely if there
+      is no bulk component.
 
 Upon receipt of a request the daemon will immediately issue an ACK response.
 The absence of a quick response indicates that the daemon is not available,
@@ -144,12 +144,10 @@ for the simple exchange outlined above::
 	b'GET'
 	b'kpfguide.LASTFILENAME'
 	b''
-	b''
 
 	b'a'
 	b'00000023'
 	b'ACK'
-	b''
 	b''
 	b''
 
@@ -158,7 +156,6 @@ for the simple exchange outlined above::
 	b'REP'
 	b''
 	b'{"value": /sdata1701/kpf1/2025-06-23/image_672.fits', "time": 234.23}'
-	b''
 
 
 .. _message_types:
@@ -408,7 +405,8 @@ message. The fields are as follows:
 
   * - **bulk**
     - A bulk byte sequence, with exactly the same contents as the
-      :ref:`request/response message <request>`.
+      :ref:`request/response message <request>`. This field will be
+      omitted entirely if there is no bulk component.
 
 
 .. _discovery:

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -54,9 +54,10 @@ in any order, in any direction.
 
 The request/response interaction between the client and daemon is a multipart
 message, where each part is required and has specific meaning. The reference
-implementation provides a :class:`mktl.protocol.Message` class to minimize
-the amount of code that has to be aware about the on-the-wire message structure.
-For both ends of the request/response exchange, the message parts are:
+implementation provides a :class:`mktl.protocol.message.Message` class to
+minimize the amount of code that has to be aware about the on-the-wire message
+structure. For both ends of the request/response exchange, the message parts
+are:
 
 .. list-table::
 
@@ -79,8 +80,8 @@ For both ends of the request/response exchange, the message parts are:
 
   * - **type**
     - The message type. This is a short string of characters that identifies
-      what type of request, or reponse, this message represents. It is one
-      of the values described in the ref:`message_types` section below.
+      what type of request, or response, this message represents. It is one
+      of the values described in the :ref:`message_types` section below.
 
   * - **target**
     - The target for this request/response, if any. Not all requests have a

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -195,6 +195,48 @@ class Message:
         logger.log(level, message, *args)
 
 
+    @classmethod
+    def reconstruct(cls, parts):
+        """ Reconstruct a :class:`Message` instance from the specified
+            sequence of message parts. This is effectively the inverse of the
+            :func:`Message._finalize` method.
+        """
+
+        if len(parts) < 6:
+            raise ValueError("multipart quantity mismatch: expected 6, got %d" % len(parts))
+
+        their_version = parts[0]
+
+        if their_version != version:
+            raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
+
+        message_id = parts[1]
+        message_type = parts[2]
+        target = parts[3]
+        payload = parts[4]
+        bulk = parts[5]
+
+        message_type = message_type.decode()
+        target = target.decode()
+
+        if bulk == b'':
+            bulk = None
+
+        if payload == b'':
+            payload = None
+        else:
+            payload = json.loads(payload)
+            try:
+                payload = Payload(**payload, bulk=bulk)
+            except TypeError:
+                # Weird stuff in the payload. Don't fail on the conversion,
+                # allow it to pass, assuming the users know what they're doing.
+                pass
+
+        message = cls(message_type, target, payload, message_id)
+        return message
+
+
 # end of class Message
 
 
@@ -358,38 +400,16 @@ class Request(Message):
             initiator of the request.
         """
 
-        if len(parts) < 6:
-            raise ValueError("multipart quantity mismatch: expected 6, got %d" % len(parts))
+        # This is a bit of a hack to work around the valid types check,
+        # but it avoids duplicating the entirety of the parent reconstruct()
+        # method.
 
-        their_version = parts[0]
+        request_type = parts[2]
+        request_type = request_type.decode()
+        parts[2] = b'REP'
 
-        if their_version != version:
-            raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
-
-        req_id = parts[1]
-        req_type = parts[2]
-        target = parts[3]
-        payload = parts[4]
-        bulk = parts[5]
-
-        req_type = req_type.decode()
-        target = target.decode()
-
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        request = cls(req_type, target, payload, req_id)
+        message = Message.reconstruct(parts)
+        request = cls(request_type, message.target, message.payload, message.id)
 
         request.ack_event = None
         request.rep_event = None

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -347,6 +347,56 @@ class Request(Message):
         return self.rep_event.is_set()
 
 
+    @classmethod
+    def reconstruct(cls, parts):
+        """ Reconstruct a :class:`Request` instance from the specified
+            sequence of message parts. This is effectively the inverse of the
+            :func:`Request._finalize` method. Reconstructed requests are not
+            expected to leverage the internal event notification scheme, those
+            aspects of a :class:`Request` are not functional as they do not
+            have meaning in this context; they are only relevant for the
+            initiator of the request.
+        """
+
+        if len(parts) < 6:
+            raise ValueError("multipart quantity mismatch: expected 6, got %d" % len(parts))
+
+        their_version = parts[0]
+
+        if their_version != version:
+            raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
+
+        req_id = parts[1]
+        req_type = parts[2]
+        target = parts[3]
+        payload = parts[4]
+        bulk = parts[5]
+
+        req_type = req_type.decode()
+        target = target.decode()
+
+        if bulk == b'':
+            bulk = None
+
+        if payload == b'':
+            payload = None
+        else:
+            payload = json.loads(payload)
+            try:
+                payload = Payload(**payload, bulk=bulk)
+            except TypeError:
+                # Weird stuff in the payload. Don't fail on the conversion,
+                # allow it to pass, assuming the users know what they're doing.
+                pass
+
+        request = cls(req_type, target, payload, req_id)
+
+        request.ack_event = None
+        request.rep_event = None
+
+        return request
+
+
     def wait_ack(self, timeout):
         """ Block until the request has been acknowledged. This is a wrapper to
             a :class:`threading.Event` instance; if the event has occurred it

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -389,34 +389,6 @@ class Request(Message):
         return self.rep_event.is_set()
 
 
-    @classmethod
-    def reconstruct(cls, parts):
-        """ Reconstruct a :class:`Request` instance from the specified
-            sequence of message parts. This is effectively the inverse of the
-            :func:`Request._finalize` method. Reconstructed requests are not
-            expected to leverage the internal event notification scheme, those
-            aspects of a :class:`Request` are not functional as they do not
-            have meaning in this context; they are only relevant for the
-            initiator of the request.
-        """
-
-        # This is a bit of a hack to work around the valid types check,
-        # but it avoids duplicating the entirety of the parent reconstruct()
-        # method.
-
-        request_type = parts[2]
-        request_type = request_type.decode()
-        parts[2] = b'REP'
-
-        message = Message.reconstruct(parts)
-        request = cls(request_type, message.target, message.payload, message.id)
-
-        request.ack_event = None
-        request.rep_event = None
-
-        return request
-
-
     def wait_ack(self, timeout):
         """ Block until the request has been acknowledged. This is a wrapper to
             a :class:`threading.Event` instance; if the event has occurred it

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -583,29 +583,4 @@ def _id_next():
     return id
 
 
-def reconstruct(mclass, parts):
-    """ Reconstruct a :class:`Message` instance from the specified sequence
-        of message parts. This is effectively the inverse of the
-        :func:`Message._finalize` method. The *mclass* argument is expected
-        to be appropriate for this message type; the caller should always
-        know which type of message it is expecting to handle.
-    """
-
-    if mclass == Broadcast:
-        return reconstruct_broadcast(parts)
-    elif mclass == Request:
-        return reconstruct_request(parts)
-    else:
-        return reconstruct_message(parts)
-
-
-def reconstruct_broadcast(parts):
-    """ Reconstruct a :class:`Broadcast` instance from the specified sequence
-        of message parts. This is effectively the inverse of the
-        :func:`Message._finalize` method. The *mclass* argument is expected
-        to be appropriate for this message type; the caller should always
-        know which type of message it is expecting to handle.
-    """
-
-
 # vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 autoindent:

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -235,6 +235,43 @@ class Broadcast(Message):
         self._parts = (target, version, payload, bulk)
 
 
+    @classmethod
+    def reconstruct(cls, parts):
+        """ Reconstruct a :class:`Broadcast` instance from the specified
+            sequence of message parts. This is effectively the inverse of the
+            :func:`Broadcast._finalize` method.
+        """
+
+        if len(parts) < 4:
+            raise ValueError("multipart quantity mismatch: expected 4, got %d" % len(parts))
+
+        topic = parts[0]
+        their_version = parts[1]
+
+        if their_version != version:
+            raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
+
+        payload = parts[2]
+        bulk = parts[3]
+
+        if bulk == b'':
+            bulk = None
+
+        if payload == b'':
+            payload = None
+        else:
+            payload = json.loads(payload)
+            try:
+                payload = Payload(**payload, bulk=bulk)
+            except TypeError:
+                # Weird stuff in the payload. Don't fail on the conversion,
+                # allow it to pass, assuming the users know what they're doing.
+                pass
+
+        broadcast = cls('PUB', topic, payload)
+        return broadcast
+
+
 # end of class Broadcast
 
 
@@ -486,6 +523,31 @@ def _id_next():
     id = '%08x' % (id)
     id = id.encode()
     return id
+
+
+def reconstruct(mclass, parts):
+    """ Reconstruct a :class:`Message` instance from the specified sequence
+        of message parts. This is effectively the inverse of the
+        :func:`Message._finalize` method. The *mclass* argument is expected
+        to be appropriate for this message type; the caller should always
+        know which type of message it is expecting to handle.
+    """
+
+    if mclass == Broadcast:
+        return reconstruct_broadcast(parts)
+    elif mclass == Request:
+        return reconstruct_request(parts)
+    else:
+        return reconstruct_message(parts)
+
+
+def reconstruct_broadcast(parts):
+    """ Reconstruct a :class:`Broadcast` instance from the specified sequence
+        of message parts. This is effectively the inverse of the
+        :func:`Message._finalize` method. The *mclass* argument is expected
+        to be appropriate for this message type; the caller should always
+        know which type of message it is expecting to handle.
+    """
 
 
 # vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 autoindent:

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -148,18 +148,22 @@ class Message:
                 pass
 
         if payload is None or payload == '':
-            bulk = b''
+            bulk = None
             payload = b''
         else:
             bulk = payload.bulk
-            if bulk is None:
-                bulk = b''
             payload = payload.encapsulate()
 
-        if self.prefix:
-            parts = self.prefix + (version, id, type, target, payload, bulk)
+        # The absence of the bulk field is the indication that it should
+        # be represented as None, distinct from being an empty byte sequence.
+
+        if bulk is None:
+            parts = (version, id, type, target, payload)
         else:
             parts = (version, id, type, target, payload, bulk)
+
+        if self.prefix:
+            parts = self.prefix + parts
 
         self._parts = parts
 
@@ -202,8 +206,10 @@ class Message:
             :func:`Message._finalize` method.
         """
 
-        if len(parts) < 6:
-            raise ValueError("multipart quantity mismatch: expected 6, got %d" % len(parts))
+        quantity = len(parts)
+
+        if quantity != 5 and quantity != 6:
+            raise ValueError("expected 5 or 6 parts, got %d" % (quantity))
 
         their_version = parts[0]
 
@@ -214,13 +220,14 @@ class Message:
         message_type = parts[2]
         target = parts[3]
         payload = parts[4]
-        bulk = parts[5]
+
+        try:
+            bulk = parts[5]
+        except IndexError:
+            bulk = None
 
         message_type = message_type.decode()
         target = target.decode()
-
-        if bulk == b'':
-            bulk = None
 
         if payload == b'':
             payload = None
@@ -265,16 +272,22 @@ class Broadcast(Message):
         target = target.encode()
 
         if payload is None or payload == '':
-            bulk = b''
+            bulk = None
             payload = b''
         else:
             bulk = payload.bulk
-            if bulk is None:
-                bulk = b''
             payload = payload.encapsulate()
 
         # The prefix is ignored for broadcast messages; it should not be set.
-        self._parts = (target, version, payload, bulk)
+        # The absence of the bulk field is the indication that it should
+        # be represented as None, distinct from being an empty byte sequence.
+
+        if bulk is None:
+            parts = (target, version, payload)
+        else:
+            parts = (target, version, payload, bulk)
+
+        self._parts = parts
 
 
     @classmethod
@@ -284,8 +297,10 @@ class Broadcast(Message):
             :func:`Broadcast._finalize` method.
         """
 
-        if len(parts) < 4:
-            raise ValueError("multipart quantity mismatch: expected 4, got %d" % len(parts))
+        quantity = len(parts)
+
+        if quantity != 3 and quantity != 4:
+            raise ValueError("expected 3 or 4 parts, got %d" % (quantity))
 
         topic = parts[0]
         their_version = parts[1]
@@ -294,9 +309,10 @@ class Broadcast(Message):
             raise ValueError("version mismatch: expected %s, got %s" % (repr(version), repr(their_version)))
 
         payload = parts[2]
-        bulk = parts[3]
 
-        if bulk == b'':
+        try:
+            bulk = parts[3]
+        except IndexError:
             bulk = None
 
         if payload == b'':

--- a/src/mktl/protocol/publish.py
+++ b/src/mktl/protocol/publish.py
@@ -56,7 +56,7 @@ class Client:
         self.thread.start()
 
 
-    def propagate(self, topic, message):
+    def propagate(self, message):
         """ Invoke any/all callbacks registered via :func:`register` for
             a newly arrived message.
         """
@@ -99,6 +99,8 @@ class Client:
             pass
         else:
             return
+
+        topic = message.target
 
         try:
             references = self.callback_specific[topic]
@@ -185,40 +187,16 @@ class Client:
 
     def _pub_incoming(self, parts):
 
-        if len(parts) < 4:
+        try:
+            broadcast = message.Broadcast.reconstruct(parts)
+        except ValueError:
             ### Malformed message. Not sure where these are coming from,
             ### but here we are. This should be logged, or at least exposed
             ### for future debugging. For now it's being dropped on the
             ### floor.
             return
 
-        topic = parts[0]
-        their_version = parts[1]
-
-        if their_version != message.version:
-            ### Maybe we should occasionally log a version mismatch.
-            ### For now it's being dropped on the floor.
-            return
-
-        payload = parts[2]
-        bulk = parts[3]
-
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = message.Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        broadcast = message.Broadcast('PUB', topic, payload)
-        self.propagate(topic, broadcast)
+        self.propagate(broadcast)
 
 
     def _sub_incoming(self):

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -386,6 +386,9 @@ class Server:
         ### exceptions are passed back to the originator of the request.
         ### Presumably that means calling something like _req_incoming().
 
+        ### As it currently stands, any exceptions occurring here are being
+        ### silently eaten by the thread pool executing this method.
+
         ident = parts[0]
         parts = parts[1:]
         request = message.Request.reconstruct(parts)

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -79,57 +79,39 @@ class Client:
             any further handling by the original caller.
         """
 
-        their_version = parts[0]
+        try:
+            response = message.Message.reconstruct(parts)
+        except:
+            ### This response is malformed somehow, and cannot be gracefully
+            ### tied back to its original request ID.
 
-        if their_version == message.version:
-            response_type = parts[2]
-            target = parts[3]
-            payload = parts[4]
-            bulk = parts[5]
-        else:
+            e_class, e_instance, e_traceback = sys.exc_info()
             error = dict()
-            error['type'] = 'RuntimeError'
-            error['text'] = "message is mKTL protocol %s, recipient expects %s" % (repr(their_version), repr(message.version))
-            payload = message.Payload(None, error=error)
-            payload = payload.encapsulate()
-            response_type = 'REP'
-            target = '???'
-            bulk = None
+            error['type'] = e_class.__name__
+            error['text'] = str(e_instance)
+            error['debug'] = traceback.format_exc()
 
-        # This could still blow up if the version doesn't match-- the id may
-        # be in a different message part-- but we have to try, otherwise
-        # there's no way to pass the error back to the original caller.
+            # Fingers crossed that this works:
+            response_id = parts[1]
 
-        response_id = parts[1]
+            payload = message.Payload(None)
+            payload.error = error
+            response = message.Message('REP', '???', payload, response_id)
+
 
         try:
-            pending = self.pending[response_id]
+            pending = self.pending[response.id]
         except KeyError:
             # The original caller's request is gone, no further processing
             # is possible.
             return
 
-        if response_type == b'ACK':
+        if response.type == 'ACK':
             pending._complete_ack()
             return
 
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = message.Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        response = message.Message('REP', target, payload, response_id)
         pending._complete(response)
-        del self.pending[response_id]
+        del self.pending[response.id]
 
 
     def _req_outgoing(self):

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -387,36 +387,10 @@ class Server:
         ### Presumably that means calling something like _req_incoming().
 
         ident = parts[0]
-        their_version = parts[1]
-
-        if their_version != message.version:
-            raise ValueError("message is mKTL protocol %s, recipient is %s" % (repr(their_version), repr(message.version)))
-
-        req_id = parts[2]
-        req_type = parts[3]
-        target = parts[4]
-        payload = parts[5]
-        bulk = parts[6]
-
-        req_type = req_type.decode()
-        target = target.decode()
-
-        if bulk == b'':
-            bulk = None
-
-        if payload == b'':
-            payload = None
-        else:
-            payload = json.loads(payload)
-            try:
-                payload = message.Payload(**payload, bulk=bulk)
-            except TypeError:
-                # Weird stuff in the payload. Don't fail on the conversion,
-                # allow it to pass, assuming the users know what they're doing.
-                pass
-
-        request = message.Request(req_type, target, payload, req_id)
+        parts = parts[1:]
+        request = message.Request.reconstruct(parts)
         request.prefix = (ident,)
+
         payload = None
         error = None
 
@@ -442,7 +416,7 @@ class Server:
             elif payload.error is None:
                 payload.error = error
 
-        response = message.Message('REP', target, payload, req_id)
+        response = message.Message('REP', request.target, payload, request.id)
         response.prefix = request.prefix
 
         self.send(response)


### PR DESCRIPTION
Make the bulk multipart component optional as a way to make the absence of bulk data distinguishable from the empty byte string.

This pull request brings over some of the concepts from https://github.com/KeckObservatory/mKTL/pull/33, with classmethods defined for the various Message classes to rebuild a Message instance from its multipart components. This means that all the handling of multipart components is now in a single file.