### PR TITLE
Replace HASH and CONFIG with GET and SET

### DIFF
--- a/doc/built_ins.rst
+++ b/doc/built_ins.rst
@@ -1,0 +1,143 @@
+
+.. _builtins:
+
+Built-in items
+==============
+
+A small set of items are defined for metadata and other internal use.
+There are two classes of built-in items: a handful that are only accessible
+at the protocol level, and the remainder that are visible as fully functional
+items in every way. The key for a built-in item has a leading underscore to
+distinguish it from other items; regular items should refrain from using a
+leading underscore.
+
+
+Protocol only
+-------------
+
+The ``_hash`` and ``_config`` items are replacements for the HASH and CONFIG
+request types that were defined in the initial prototype of the mKTL protocol.
+
+.. list-table::
+
+  * - *Key*
+    - *Description*
+
+  * - **_hash**
+    - Request the current hash identifiers for any known configuration blocks
+      of a single mKTL store. All available hash identifiers, for all known
+      stores, will be returned for a query of the bare ``_hash`` item; with a
+      store name prefix, such as `kpfguide._hash`, only the hashes for that
+      specific store will be returned. An error will be returned if a store
+      is requested and the responding daemon does not have a cached
+      configuration for that store.
+
+      To rephrase, the scope for a ``_hash`` item is at two levels:
+
+        * ``_hash``: returning all locally known hash data
+        * ``store._hash``: returning only the hash data for the requested store
+
+      The hash is 32 hexadecimal integers. The actual hash format is not
+      significant, as long as the source of authority is consistent about
+      which hash format it uses, and the format can be transmitted as 32
+      hexadecimal integers.
+
+      All ``_hash`` items are read-only, and can only receive GET requests.
+
+      To unify processing the response value is always a dictionary of
+      dictionaries, even if only one hash is available.
+
+      Example response values::
+
+        {'kpfguide': {'uuid1': 0x84a30b35...,
+                      'uuid2': 0x983ae10f...}}
+
+        {'kpfguide': {'uuid1': 0x84a30b35...,
+                      'uuid2': 0x983ae10f...},
+         'kpfmet': {'uuid6': 0xe0377e7d...,
+                    'uuid7': 0x7735a20a...,
+                    'uuid8': 0x88645dab...,
+                    'uuid9': 0x531c14fd...}}
+
+
+  * - **_config**
+    - The full locally known configuration contents for a single mKTL store.
+      There is no bare ``_config`` item available to request the configuration
+      data for all locally known stores; the key will always include the store
+      name, such as `kpfguide._config`.
+
+      The scope for a ``_config`` item is at two levels:
+
+        * ``store._config``: represents the config data for the requested store
+        * ``store._aliascfg``: represents the config data for a single daemon
+
+      A typical client interaction will request the configuration hash first,
+      and if the hash for the cached local copy is not a match, request the
+      full contents from the daemon to update the local cache.
+
+      The configuration contents are not fully described here, this is just
+      a description of the request. See the
+      :ref:`configuration documentation <configuration>` for a full description
+      of the data format.
+
+      A SET operation on a ``_config`` item should only originate from an
+      authoritative daemon; as such, it will be treated as an announcement,
+      and any errors raised by the recipient have to be treated as a rejection
+      of the announcement.
+
+
+These two item definitions are critical for the exchange of their respective
+data; both are integral to the initial handshake between a client and a daemon,
+and between any intermediaries aiding in the discovery process.
+
+
+Fully functional
+----------------
+
+The remaining built-in items are visible in the configuration for the store,
+and are implemented on a per-daemon basis. They are intended to represent
+metadata about an individual daemon, will all have the store name and alias
+as the first elements of the key, including a leading underscore after the
+store name; for example, ``kpfguide._disp1``. The built-in items append a
+functional suffix to this common prefix.
+
+The built-in items defined in this fashion are typically read-only, though
+there are some exceptions.
+
+
+.. list-table::
+
+  * - *Key suffix*
+    - *Description*
+
+  * - **cfg**
+    - See the description of the ``_config`` item above.
+
+  * - **clk**
+    - The current uptime for this daemon, measured in seconds. The value will
+      update and publish on a 1 Hz basis and can be used as a heartbeat
+      indicator to assess whether the daemon is running normally.
+
+  * - **cpu**
+    - An instantaneous measurement of the processor consumption by this daemon.
+      This value will udpate and publish on a 1 Hz basis.
+
+  * - **dev**
+    - A terse description of the function of this daemon. This item is settable,
+      and its value will persist across restarts.
+
+  * - **host**
+    - The locally defined hostname for where this daemon is running.
+      No guarantees are made about the external validity of this name.
+
+  * - **mem**
+    - An instantaneous measurement of the physical memory consumption by this
+      daemon. This value will udpate and publish on a 1 Hz basis.
+
+  * - **pid**
+    - The proces identifier for this daemon.
+
+  * - **uuid**
+    - The universally unique identifier (UUID) for this daemon; this identifier
+      will persist across restats.
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,6 +33,7 @@ be expert mKTL maintainers in order to successfully develop an application.
    examples
    executables
    configuration
+   built_ins
    protocol
    protocol_interface
    code_of_conduct

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -202,48 +202,6 @@ also exists, but has its own message structure outside this scheme.
       expected, and there are additional fields set by the client to describe
       the origin of the request.
 
-  * - **HASH**
-    - Request the current hash identifiers for any known configuration blocks
-      of a single mKTL store. All available hash identifiers, for all known
-      stores, will be returned if no store name is specified in the target
-      field. An error will be
-      returned if a store is requested and the responding daemon does not have
-      a cached configuration for that store.
-
-      The hash is 32 hexadecimal integers. The actual hash format is not
-      significant, as long as the source of authority is consistent about
-      which hash format it uses, and the format can be transmitted as 32
-      hexadecimal integers.
-
-      To unify processing the response value is always a dictionary of
-      dictionaries, even if only one hash is available.
-
-      Example response values::
-
-	{'kpfguide': {'uuid1': 0x84a30b35...,
-		      'uuid2': 0x983ae10f...}}
-
-	{'kpfguide': {'uuid1': 0x84a30b35...,
-		      'uuid2': 0x983ae10f...},
-	 'kpfmet': {'uuid6': 0xe0377e7d...,
-		    'uuid7': 0x7735a20a...,
-		    'uuid8': 0x88645dab...,
-		    'uuid9': 0x531c14fd...}}
-
-
-  * - **CONFIG**
-    - Request the full configuration contents for a single mKTL store.
-      There is no option to dump the configuration data for all known stores,
-      a target must always be specified.
-      A typical client interaction will request the configuration hash first,
-      and if the hash for the cached local copy is not a match, request the
-      full contents from the daemon to update the local cache.
-
-      The configuration contents are not fully described here, this is just
-      a description of the request. See the
-      :ref:`configuration documentation <configuration>` for a full description
-      of the data format.
-
   * - **ACK**
     - Immediate acknowledgement of a request; this message type originates from
       a daemon, only in response to a request. If this response is not received

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -51,6 +51,7 @@ def main():
 
             address,port = seen
             request = mktl.protocol.message.Request('HASH')
+            #request = mktl.protocol.message.Request('GET', '_hash')
             try:
                 payload = mktl.protocol.request.send(address, port, request)
             except:
@@ -61,6 +62,7 @@ def main():
 
             for store in hashes.keys():
                 request = mktl.protocol.message.Request('CONFIG', store)
+                #request = mktl.protocol.message.Request('GET', store + '._config')
                 payload = mktl.protocol.request.send(address, port, request)
 
                 blocks = payload.value
@@ -395,6 +397,35 @@ class RequestServer(mktl.protocol.request.Server):
         return payload
 
 
+    def req_get(self, request):
+        """ We are expecting queries for hash and configuration data, aimed
+            at specially named built-in keys.
+        """
+
+        target = request.target
+
+        if target == '_hash':
+            payload_data = mktl.config.get_hashes()
+        else:
+            store,key = target.split('.', 1)
+
+            if key == '_hash':
+                payload_data = mktl.config.get_hashes(store)
+            elif key == '_config':
+                try:
+                    config = mktl.config.get(store)
+                except KeyError:
+                    payload_data = tuple()
+                else:
+                    payload_data = config._by_uuid
+            else:
+                raise ValueError('unhandled key: ' + target)
+
+
+        payload = mktl.Payload(payload_data)
+        return payload
+
+
     def req_handler(self, request):
         """ Inspect the incoming request type and decide how a response
             will be generated.
@@ -408,12 +439,16 @@ class RequestServer(mktl.protocol.request.Server):
         if type != 'HASH' and target == '':
             raise KeyError('invalid request, no store/name specified')
 
-        if type == 'HASH':
+        if type == 'GET':
+            payload = self.req_get(request)
+        elif type == 'SET':
+            payload = self.req_set(request)
+        elif type == 'HASH':
             payload = self.req_hash(request)
         elif type == 'CONFIG':
             payload = self.req_config(request)
         else:
-            raise ValueError('invalid request type: ' + type)
+            raise ValueError('unhandled request: ' + type)
 
         return payload
 
@@ -433,6 +468,28 @@ class RequestServer(mktl.protocol.request.Server):
             raise KeyError('no local configuration for ' + repr(store))
 
         payload = mktl.Payload(hashes)
+        return payload
+
+
+    def req_set(self, request):
+        """ We are expecting queries for configuration data, aimed
+            at specially named built-in keys.
+        """
+
+        # We could be inspecting the request.target value to ensure it
+        # matches the provided configuration blocks. For now, just process
+        # whatever we get.
+
+        blocks = request.payload.value
+
+        for uuid,block in blocks.items():
+            try:
+                self.process_block(block)
+            except ProvenanceLoopError:
+                # This configuration block came from us. Pay no mind.
+                pass
+
+        payload = mktl.Payload(True)
         return payload
 
 

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -375,6 +375,8 @@ class RequestServer(mktl.protocol.request.Server):
             key = '_hash'
         else:
             store, key = target.split('.', 1)
+            if store == '':
+                store = None
 
         if key == '_hash':
             payload_data = mktl.config.get_hashes(store)

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -50,8 +50,7 @@ def main():
             # configuration blocks discovered in this fashion.
 
             address,port = seen
-            request = mktl.protocol.message.Request('HASH')
-            #request = mktl.protocol.message.Request('GET', '_hash')
+            request = mktl.protocol.message.Request('GET', '_hash')
             try:
                 payload = mktl.protocol.request.send(address, port, request)
             except:
@@ -60,9 +59,19 @@ def main():
 
             hashes = payload.value
 
+            if hashes is None:
+                # Error requesting the hashes.
+                logger.warning("HASH request from %s:%d failed" % (address, port))
+                error = payload.error
+                if error:
+                    e_type = error['type']
+                    e_text = error['text']
+                    e_debug = error['debug']
+                    logger.warning("Remote exception: %s: %s\n%s" % (e_type, e_text, e_debug))
+                continue
+
             for store in hashes.keys():
-                request = mktl.protocol.message.Request('CONFIG', store)
-                #request = mktl.protocol.message.Request('GET', store + '._config')
+                request = mktl.protocol.message.Request('GET', store + '._config')
                 payload = mktl.protocol.request.send(address, port, request)
 
                 blocks = payload.value
@@ -354,72 +363,30 @@ class RequestServer(mktl.protocol.request.Server):
         config.update(new)
 
 
-    def req_config(self, request):
-        """ When a daemon announces a configuration block it will be the payload
-            of the request, otherwise, for a query the payload is empty. The
-            response for a payload is ignored, though the presence or absence of
-            exceptions is significant. The response to a configuration request
-            is a sequence of configuration blocks representing the full known
-            configuration for the specified store, with a single block
-            corresponding to a single daemon.
-        """
-
-        store = request.target
-        payload = request.payload
-
-        if payload is None or payload.value is None:
-            try:
-                config = mktl.config.get(store)
-            except KeyError:
-                response = tuple()
-            else:
-                response = config._by_uuid
-
-            if len(response) == 0:
-                raise KeyError('no configuration available for ' + repr(store))
-
-        else:
-            response = True
-            block = payload.value
-
-            try:
-                self.process_block(block)
-            except ProvenanceLoopError:
-                # This configuration block came from us. Pay no mind.
-                pass
-
-            provenance = block['provenance'][0]
-            seen = (provenance['hostname'], provenance['rep'])
-            main.known.add(seen)
-
-
-        payload = mktl.Payload(response)
-        return payload
-
-
     def req_get(self, request):
         """ We are expecting queries for hash and configuration data, aimed
-            at specially named built-in keys.
+            at specially named built-in keys '_hash' and '_config'.
         """
 
         target = request.target
 
         if target == '_hash':
-            payload_data = mktl.config.get_hashes()
+            store = None
+            key = '_hash'
         else:
-            store,key = target.split('.', 1)
+            store, key = target.split('.', 1)
 
-            if key == '_hash':
-                payload_data = mktl.config.get_hashes(store)
-            elif key == '_config':
-                try:
-                    config = mktl.config.get(store)
-                except KeyError:
-                    payload_data = tuple()
-                else:
-                    payload_data = config._by_uuid
+        if key == '_hash':
+            payload_data = mktl.config.get_hashes(store)
+        elif key == '_config':
+            try:
+                config = mktl.config.get(store)
+            except KeyError:
+                payload_data = tuple()
             else:
-                raise ValueError('unhandled key: ' + target)
+                payload_data = config._by_uuid
+        else:
+            raise ValueError('unhandled key: ' + target)
 
 
         payload = mktl.Payload(payload_data)
@@ -436,38 +403,13 @@ class RequestServer(mktl.protocol.request.Server):
         type = request.type
         target = request.target
 
-        if type != 'HASH' and target == '':
-            raise KeyError('invalid request, no store/name specified')
-
         if type == 'GET':
             payload = self.req_get(request)
         elif type == 'SET':
             payload = self.req_set(request)
-        elif type == 'HASH':
-            payload = self.req_hash(request)
-        elif type == 'CONFIG':
-            payload = self.req_config(request)
         else:
             raise ValueError('unhandled request: ' + type)
 
-        return payload
-
-
-    def req_hash(self, request):
-        """ Return the hash of a configuration block for a requested store name,
-            or all hashes for all locally known stores.
-        """
-
-        store = request.target
-        if store == '':
-            store = None
-
-        try:
-            hashes = mktl.config.get_hashes(store)
-        except KeyError:
-            raise KeyError('no local configuration for ' + repr(store))
-
-        payload = mktl.Payload(hashes)
         return payload
 
 

--- a/src/mktl/begin.py
+++ b/src/mktl/begin.py
@@ -50,7 +50,7 @@ def discover(*targets):
     protocol.request.Client.timeout = 0.5
 
     for address,port in brokers:
-        request = protocol.message.Request('HASH')
+        request = protocol.message.Request('GET', '_hash')
         try:
             payload = protocol.request.send(address, port, request)
         except:
@@ -59,7 +59,8 @@ def discover(*targets):
         hashes = payload.value
 
         for store in hashes.keys():
-            request = protocol.message.Request('CONFIG', store)
+            key = store + '._config'
+            request = protocol.message.Request('GET', key)
             payload = protocol.request.send(address, port, request)
 
             blocks = payload.value
@@ -138,7 +139,8 @@ def get(store, key=None):
             raise RuntimeError("no configuration available for '%s' (local or remote)" % (store))
 
         hostname,port = brokers[0]
-        message = protocol.message.Request('CONFIG', store)
+        key = store + '._config'
+        message = protocol.message.Request('GET', key)
         payload = protocol.request.send(hostname, port, message)
 
         blocks = payload.value
@@ -199,8 +201,9 @@ def refresh(configuration):
             hostname = stratum['hostname']
             rep = stratum['rep']
 
+            key = store + '._hash'
             client = protocol.request.client(hostname, rep)
-            request = protocol.message.Request('HASH', store)
+            request = protocol.message.Request('GET', key)
 
             try:
                 client.send(request)
@@ -235,7 +238,8 @@ def refresh(configuration):
 
             if local_hash != remote_hash:
                 # Mismatch; need to request an update before proceeding.
-                message = protocol.message.Request('CONFIG', store)
+                key = store + '._config'
+                message = protocol.message.Request('GET', key)
                 client.send(message)
                 ### Again, exception handling may be required, though the
                 ### previous request went through, so there shouldn't be a
@@ -255,7 +259,7 @@ def refresh(configuration):
 
                 # This is not checking to see whether the UUID is present in the
                 # results-- it is assumed, because the UUID was present in the
-                # response to the HASH query prior to reaching this point.
+                # response to the _hash query prior to reaching this point.
 
                 new_block = new_config[uuid]
                 configuration.update(new_block)

--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -24,6 +24,8 @@ from . import protocol
 _cache = dict()
 _cache_lock = threading.Lock()
 
+_callbacks = list()
+
 
 class Configuration:
     """ A convenience class to represent mKTL configuration data. To first
@@ -577,6 +579,19 @@ class Configuration:
 
         for reference in invalid:
             self.callbacks.remove(reference)
+
+        invalid = list()
+
+        for reference in _callbacks:
+            callback = reference()
+
+            if callback is None:
+                invalid.append(reference)
+            else:
+                callback()
+
+        for reference in invalid:
+            _callbacks.remove(reference)
 
 
     def register(self, method):
@@ -1521,6 +1536,24 @@ def match_provenance(full_provenance1, full_provenance2):
 
         matched = True
         index += 1
+
+
+
+def register(method):
+    """ Register a callback to be invoked whenever any configuration
+        instance receives an update. The callback should take no additional
+        arguments.
+    """
+
+    if callable(method):
+        pass
+    else:
+        raise TypeError('the registered method must be callable')
+
+    reference = weakref.ref(method)
+    _callbacks.append(reference)
+
+    method()
 
 
 

--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -1267,15 +1267,20 @@ def announce(config, uuid, override=False):
     """
 
     store = config.store
+    key = store + '.config'
+
     block = config[uuid]
     block = dict(block)
 
     if override == True:
         block['override'] = True
 
-    payload = protocol.message.Payload(block)
+    blocks = dict()
+    blocks[uuid] = block
+
+    payload = protocol.message.Payload(blocks)
     payload.add_origin()
-    message = protocol.message.Request('CONFIG', store, payload)
+    message = protocol.message.Request('SET', key, payload)
 
     brokers = protocol.discover.search(wait=True)
 

--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import uuid
+import weakref
 
 # Importing pint is expensive, representing something like 30% of the
 # user runtime for a simple mKTL command. It will be imported on a
@@ -47,6 +48,8 @@ class Configuration:
         self._by_uuid = dict()
         self._by_alias = dict()
         self._by_key = dict()
+
+        self.callbacks = list()
 
         if store in _cache:
             raise ValueError('Configuration class is a singleton')
@@ -551,6 +554,46 @@ class Configuration:
             configuration['items'] = json.loads(raw_json)
 
         return configuration,target_uuid
+
+
+    def _propagate(self):
+        """ Invoke any registered callbacks upon a configuration update.
+        """
+
+        if self.callbacks:
+            pass
+        else:
+            return
+
+        invalid = list()
+
+        for reference in self.callbacks:
+            callback = reference()
+
+            if callback is None:
+                invalid.append(reference)
+            else:
+                callback()
+
+        for reference in invalid:
+            self.callbacks.remove(reference)
+
+
+    def register(self, method):
+        """ Register a callback to be invoked whenever this configuration
+            instance receives an update. The callback should take no additional
+            arguments.
+        """
+
+        if callable(method):
+            pass
+        else:
+            raise TypeError('the registered method must be callable')
+
+        reference = weakref.ref(method)
+        self.callbacks.append(reference)
+
+        method()
 
 
     def _reject_units(self, *args, **kwargs):
@@ -1123,6 +1166,8 @@ class Configuration:
 
         if save == True:
             self._save_client(block)
+
+        self._propagate()
 
 
     def uuids(self, authoritative=False):

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -320,7 +320,7 @@ class Daemon:
         items[key]['units'] = 'seconds'
         items[key]['format'] = '%.3f'
 
-        key = '_' + self.alias + 'con'
+        key = '_' + self.alias + 'cfg'
         items[key] = dict()
         items[key]['description'] = 'JSON description of all items for this daemon.'
         items[key]['settable'] = False
@@ -368,7 +368,7 @@ class Daemon:
         # Having updated the configuration, now instantiate the built-in items.
 
         self.add_item(Uptime, '_' + self.alias + 'clk')
-        self.add_item(DaemonConfiguration, '_' + self.alias + 'conf')
+        self.add_item(DaemonConfiguration, '_' + self.alias + 'cfg')
         self.add_item(ProcessorUsage, '_' + self.alias + 'cpu')
         self.add_item(MemoryUsage, '_' + self.alias + 'mem')
         self.add_item(StoreConfiguration, '_config')

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -309,15 +309,6 @@ class Daemon:
         block = self.config.authoritative_block
         items = block['items']
 
-        key = '_config'
-        items[key] = dict()
-        items[key]['description'] = 'JSON description of all items for this store.'
-
-        key = '_hash'
-        items[key] = dict()
-        items[key]['description'] = 'Hashes for all known configuration blocks for this store.'
-        items[key]['settable'] = False
-
         key = '_' + self.alias + 'clk'
         items[key] = dict()
         items[key]['description'] = 'Uptime for this daemon.'
@@ -376,8 +367,6 @@ class Daemon:
         self.add_item(DaemonConfiguration, '_' + self.alias + 'cfg')
         self.add_item(ProcessorUsage, '_' + self.alias + 'cpu')
         self.add_item(MemoryUsage, '_' + self.alias + 'mem')
-        self.add_item(StoreConfiguration, '_config')
-        self.add_item(StoreHash, '_hash')
 
         for suffix in ('dev', 'host'):
             key = '_' + self.alias + suffix
@@ -939,60 +928,6 @@ class ProcessorUsage(item.Item):
 
 
 # end of class ProcessorUsage
-
-
-
-class StoreConfiguration(item.Item):
-
-    def __init__(self, *args, **kwargs):
-
-        item.Item.__init__(self, *args, **kwargs)
-        self.publish_on_set = False
-
-        configuration = config.get(self.store.name)
-        configuration.register(self.req_poll)
-
-
-    def perform_get(self):
-
-        configuration = config.get(self.store.name)
-        configuration = configuration._by_uuid
-        return configuration
-
-
-    def perform_set(self, new_config):
-
-        configuration = config.get(self.store.name)
-
-        for uuid,block in new_config:
-            if uuid == self.store._daemon.uuid:
-                # Silently drop any block describing our local daemon.
-                continue
-
-            configuration.update(block)
-
-
-# end of class StoreConfiguration
-
-
-
-class StoreHash(item.Item):
-
-    def __init__(self, *args, **kwargs):
-
-        item.Item.__init__(self, *args, **kwargs)
-
-        configuration = config.get(self.store.name)
-        configuration.register(self.req_poll)
-
-
-    def perform_get(self):
-
-        hashes = config.get_hashes(self.store.name)
-        return hashes
-
-
-# end of class StoreHash
 
 
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -97,9 +97,9 @@ class Daemon:
         avoid = _used_ports()
 
         try:
-            self.rep = RequestServer(self, port=rep, avoid=avoid)
+            self.rep = RequestServer(self, store, port=rep, avoid=avoid)
         except ConnectionError:
-            self.rep = RequestServer(self, port=None, avoid=avoid)
+            self.rep = RequestServer(self, store, port=None, avoid=avoid)
 
         _save_port(store, self.uuid, self.rep.port, self.pub.port)
 
@@ -446,7 +446,8 @@ class Daemon:
         """
 
         hostname = socket.getfqdn()
-        request = protocol.message.Request('CONFIG', store)
+        key = store + '._config'
+        request = protocol.message.Request('GET', key)
 
         try:
             payload = protocol.request.send(hostname, port, request)
@@ -455,10 +456,6 @@ class Daemon:
             return
 
         blocks = payload.value
-
-        # There should only be one UUID in this block, because we're asking
-        # a direct question of an authoritative daemon running on the same
-        # host we're trying to run on. But that assumption is not being checked.
 
         for uuid,block in blocks.items():
             alias = block['alias']
@@ -477,32 +474,16 @@ class Daemon:
 
 class RequestServer(protocol.request.Server):
 
-    def __init__(self, daemon, *args, **kwargs):
+    def __init__(self, daemon, store, *args, **kwargs):
         protocol.request.Server.__init__(self, *args, **kwargs)
         self.daemon = daemon
+        self.store = store
+
         self._getters = dict()
-
-
-    def req_config(self, request):
-
-        target = request.target
-        response = dict()
-
-        if self.daemon.store is None:
-            raise RuntimeError('daemon not ready to accept CONFIG request')
-
-        if target == self.daemon.store.name:
-            uuid = self.daemon.uuid
-            configuration = dict(self.daemon.config[uuid])
-            response[uuid] = configuration
-        else:
-            configuration = config.get(target)
-            uuids = configuration.uuids()
-            for uuid in uuids:
-                response[uuid] = config[uuid]
-
-        payload = protocol.message.Payload(response)
-        return payload
+        self._getters[store + '._config'] = self.req_get_config
+        self._getters[store + '._hash'] = self.req_get_hash
+        self._getters['._hash'] = self.req_get_hash
+        self._getters['_hash'] = self.req_get_hash
 
 
     def req_handler(self, request):
@@ -515,17 +496,10 @@ class RequestServer(protocol.request.Server):
         type = request.type
         target = request.target
 
-        if target == '' and type != 'HASH' and type != 'CONFIG':
-            raise KeyError("invalid %s request, 'target' not set" % (type))
-
-        if type == 'HASH':
-            response = self.req_hash(request)
-        elif type == 'SET':
+        if type == 'SET':
             response = self.req_set(request)
         elif type == 'GET':
             response = self.req_get(request)
-        elif type == 'CONFIG':
-            response = self.req_config(request)
         else:
             raise ValueError('unhandled request type: ' + type)
 
@@ -564,7 +538,24 @@ class RequestServer(protocol.request.Server):
 
         configuration = config.get(store)
         configuration = configuration._by_uuid
-        return configuration
+        payload = protocol.message.Payload(configuration)
+        return payload
+
+
+    def req_get_hash(self, request):
+
+        target = request.target
+
+        if target == '_hash':
+            store = None
+        else:
+            store, key = target.split('.', 1)
+            if store == '':
+                store = None
+
+        hashes = config.get_hashes(store)
+        payload = protocol.message.Payload(hashes)
+        return payload
 
 
     def req_set(self, request):
@@ -592,17 +583,6 @@ class RequestServer(protocol.request.Server):
 
         response = self.daemon.store[key].req_set(request)
         return response
-
-
-    def req_hash(self, request):
-
-        store = request.target
-        if store == '':
-            store = None
-
-        hashes = config.get_hashes(store)
-        payload = protocol.message.Payload(hashes)
-        return payload
 
 
 # end of class RequestServer

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -313,6 +313,11 @@ class Daemon:
         items[key] = dict()
         items[key]['description'] = 'JSON description of all items for this store.'
 
+        key = '_hash'
+        items[key] = dict()
+        items[key]['description'] = 'Hashes for all known configuration blocks for this store.'
+        items[key]['settable'] = False
+
         key = '_' + self.alias + 'clk'
         items[key] = dict()
         items[key]['description'] = 'Uptime for this daemon.'
@@ -372,6 +377,7 @@ class Daemon:
         self.add_item(ProcessorUsage, '_' + self.alias + 'cpu')
         self.add_item(MemoryUsage, '_' + self.alias + 'mem')
         self.add_item(StoreConfiguration, '_config')
+        self.add_item(StoreHash, '_hash')
 
         for suffix in ('dev', 'host'):
             key = '_' + self.alias + suffix
@@ -987,6 +993,26 @@ class StoreConfiguration(item.Item):
 
 
 # end of class StoreConfiguration
+
+
+
+class StoreHash(item.Item):
+
+    def __init__(self, *args, **kwargs):
+
+        item.Item.__init__(self, *args, **kwargs)
+
+        configuration = config.get(self.store.name)
+        configuration.register(self.req_poll)
+
+
+    def perform_get(self):
+
+        hashes = config.get_hashes(self.store.name)
+        return hashes
+
+
+# end of class StoreHash
 
 
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -378,10 +378,6 @@ class Daemon:
         self.add_item(ProcessorUsage, '_' + self.alias + 'cpu')
         self.add_item(MemoryUsage, '_' + self.alias + 'mem')
 
-        for suffix in ('dev', 'host'):
-            key = '_' + self.alias + suffix
-            self.add_item(item.Item, key)
-
 
     def _setup_missing(self):
         """ Inspect the locally known list of :class:`mktl.Item` instances;

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -309,16 +309,17 @@ class Daemon:
         block = self.config.authoritative_block
         items = block['items']
 
+        key = '_' + self.alias + 'cfg'
+        items[key] = dict()
+        items[key]['description'] = 'JSON description of all items for this daemon.'
+        items[key]['settable'] = False
+
         key = '_' + self.alias + 'clk'
         items[key] = dict()
         items[key]['description'] = 'Uptime for this daemon.'
         items[key]['type'] = 'numeric'
         items[key]['units'] = 'seconds'
         items[key]['format'] = '%.3f'
-
-        key = '_' + self.alias + 'cfg'
-        items[key] = dict()
-        items[key]['description'] = 'JSON description of all items for this daemon.'
         items[key]['settable'] = False
 
         key = '_' + self.alias + 'cpu'

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -358,11 +358,20 @@ class Daemon:
         items[key]['initial'] = os.getpid()
         items[key]['settable'] = False
 
+        key = '_' + self.alias + 'uuid'
+        items[key] = dict()
+        items[key]['description'] = 'Universally unique identifier (UUID) for this daemon.'
+        items[key]['type'] = 'string'
+        items[key]['initial'] = self.uuid
+        items[key]['settable'] = False
+
         self.config.update(block, save=False)
         self.store._update_config()
 
 
-        # Having updated the configuration, now instantiate the built-in items.
+        # Instantiate any custom item subclasses for the newly defined
+        # built-in items; this is only possible after the configuration
+        # has been updated.
 
         self.add_item(Uptime, '_' + self.alias + 'clk')
         self.add_item(DaemonConfiguration, '_' + self.alias + 'cfg')

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -309,12 +309,21 @@ class Daemon:
         block = self.config.authoritative_block
         items = block['items']
 
+        key = '_config'
+        items[key] = dict()
+        items[key]['description'] = 'JSON description of all items for this store.'
+
         key = '_' + self.alias + 'clk'
         items[key] = dict()
         items[key]['description'] = 'Uptime for this daemon.'
         items[key]['type'] = 'numeric'
         items[key]['units'] = 'seconds'
         items[key]['format'] = '%.3f'
+
+        key = '_' + self.alias + 'con'
+        items[key] = dict()
+        items[key]['description'] = 'JSON description of all items for this daemon.'
+        items[key]['settable'] = False
 
         key = '_' + self.alias + 'cpu'
         items[key] = dict()
@@ -359,8 +368,10 @@ class Daemon:
         # Having updated the configuration, now instantiate the built-in items.
 
         self.add_item(Uptime, '_' + self.alias + 'clk')
-        self.add_item(MemoryUsage, '_' + self.alias + 'mem')
+        self.add_item(DaemonConfiguration, '_' + self.alias + 'con')
         self.add_item(ProcessorUsage, '_' + self.alias + 'cpu')
+        self.add_item(MemoryUsage, '_' + self.alias + 'mem')
+        self.add_item(StoreConfiguration, '_config')
 
         for suffix in ('dev', 'host'):
             key = '_' + self.alias + suffix
@@ -464,6 +475,19 @@ class RequestServer(protocol.request.Server):
         protocol.request.Server.__init__(self, *args, **kwargs)
         self.daemon = daemon
 
+        daemon.config.register(self.clear_handlers)
+
+
+    def clear_handlers(self):
+        self._getters = dict()
+        self._setters = dict()
+
+        if self.daemon.store is None:
+            # Still initializing.
+            return
+
+        self._getters[self.daemon.store.name + '._config'] = self.req_get_config
+
 
     def req_config(self, request):
 
@@ -516,6 +540,13 @@ class RequestServer(protocol.request.Server):
 
     def req_get(self, request):
 
+        try:
+            getter = self._getters[request.target]
+        except KeyError:
+            pass
+        else:
+            return getter(request)
+
         store, key = request.target.split('.', 1)
 
         if store != self.daemon.store.name:
@@ -528,8 +559,18 @@ class RequestServer(protocol.request.Server):
         else:
             raise KeyError('this daemon does not contain ' + repr(key))
 
-        response = self.daemon.store[key].req_get(request)
-        return response
+        getter = self.daemon.store[key].req_get
+        self._getters[request.target] = getter
+        return getter(request)
+
+
+    def req_get_config(self, request):
+
+        store, key = request.target.split('.', 1)
+
+        configuration = config.get(store)
+        configuration = configuration._by_uuid
+        return configuration
 
 
     def req_set(self, request):
@@ -856,6 +897,21 @@ class PendingPersistence:
 
 
 
+class DaemonConfiguration(item.Item):
+
+    def perform_get(self):
+
+        uuid = self.store._daemon.uuid
+        configuration = config.get(self.store.name)
+        configuration = configuration[uuid]
+
+        return configuration
+
+
+# end of class DaemonConfiguration
+
+
+
 class MemoryUsage(item.Item):
 
     def __init__(self, *args, **kwargs):
@@ -909,6 +965,42 @@ class ProcessorUsage(item.Item):
 
 
 # end of class ProcessorUsage
+
+
+
+class StoreConfiguration(item.Item):
+    ### Is this class necessary at the per-daemon level? Or should it strictly
+    ### be the purview of the broker/registry?
+
+    def __init__(self, *args, **kwargs):
+
+        item.Item.__init__(self, *args, **kwargs)
+        self.publish_on_set = False
+
+        configuration = config.get(self.store.name)
+        configuration.register(self.req_poll)
+
+
+    def perform_get(self):
+
+        configuration = config.get(self.store.name)
+        configuration = configuration._by_uuid
+        return configuration
+
+
+    def perform_set(self, new_config):
+
+        configuration = config.get(self.store.name)
+
+        for uuid,block in new_config:
+            if uuid == self.store._daemon.uuid:
+                # Silently drop any block describing our local daemon.
+                continue
+
+            configuration.update(block)
+
+
+# end of class StoreConfiguration
 
 
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -368,7 +368,7 @@ class Daemon:
         # Having updated the configuration, now instantiate the built-in items.
 
         self.add_item(Uptime, '_' + self.alias + 'clk')
-        self.add_item(DaemonConfiguration, '_' + self.alias + 'con')
+        self.add_item(DaemonConfiguration, '_' + self.alias + 'conf')
         self.add_item(ProcessorUsage, '_' + self.alias + 'cpu')
         self.add_item(MemoryUsage, '_' + self.alias + 'mem')
         self.add_item(StoreConfiguration, '_config')
@@ -474,19 +474,7 @@ class RequestServer(protocol.request.Server):
     def __init__(self, daemon, *args, **kwargs):
         protocol.request.Server.__init__(self, *args, **kwargs)
         self.daemon = daemon
-
-        daemon.config.register(self.clear_handlers)
-
-
-    def clear_handlers(self):
         self._getters = dict()
-        self._setters = dict()
-
-        if self.daemon.store is None:
-            # Still initializing.
-            return
-
-        self._getters[self.daemon.store.name + '._config'] = self.req_get_config
 
 
     def req_config(self, request):
@@ -969,8 +957,6 @@ class ProcessorUsage(item.Item):
 
 
 class StoreConfiguration(item.Item):
-    ### Is this class necessary at the per-daemon level? Or should it strictly
-    ### be the purview of the broker/registry?
 
     def __init__(self, *args, **kwargs):
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -249,7 +249,7 @@ class Request(Message):
         :ivar response: The response (as a :class:`Message`) to this request
     """
 
-    valid_types = set(('CONFIG', 'GET', 'HASH', 'SET'))
+    valid_types = set(('GET', 'SET'))
 
     def __init__(self, type, target=None, payload=None, id=None):
 


### PR DESCRIPTION
This pull request eliminates the HASH and CONFIG request types in favor of using GET and SET with built-in item names to implement the same behavior. The built-in items are:

    _hash
    storename._hash
    storename._config