### PR TITLE
Sparse payload

### DIFF
--- a/bin/mk
+++ b/bin/mk
@@ -503,7 +503,11 @@ def execute_set_requests(requests):
             key = request.target
             value = request.payload.value
             response = request.response
-            error = response.payload.error
+
+            try:
+                error = response.payload.error
+            except AttributeError:
+                error = None
 
             if error is not None and error != '':
                 sys.stderr.write("%s failed: %s: %s\n" % (key, error['type'], error['text']))

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -208,7 +208,7 @@ class RequestServer(mktl.protocol.request.Server):
         clock = '_' + alias + 'clk'
         key = store + '.' + clock
 
-        payload = mktl.protocol.message.Payload(None, refresh=True)
+        payload = mktl.protocol.message.Payload(refresh=True)
         request = mktl.protocol.message.Request('GET', key, payload)
 
         # Traverse the provenance by highest stratum number first.
@@ -391,7 +391,7 @@ class RequestServer(mktl.protocol.request.Server):
             main.known.add(seen)
 
 
-        payload = mktl.Payload(response)
+        payload = mktl.Payload(value=response)
         return payload
 
 
@@ -432,7 +432,7 @@ class RequestServer(mktl.protocol.request.Server):
         except KeyError:
             raise KeyError('no local configuration for ' + repr(store))
 
-        payload = mktl.Payload(hashes)
+        payload = mktl.Payload(value=hashes)
         return payload
 
 

--- a/sbin/mkbrokerd
+++ b/sbin/mkbrokerd
@@ -64,7 +64,11 @@ def main():
                 payload = mktl.protocol.request.send(address, port, request)
 
                 blocks = payload.value
-                error = payload.error
+
+                try:
+                    error = payload.error
+                except AttributeError:
+                    error = None
 
                 if error:
                     e_type = error['type']

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -428,14 +428,13 @@ class RequestServer(mktl.protocol.request.Server):
         # matches the provided configuration blocks. For now, just process
         # whatever we get.
 
-        blocks = request.payload.value
+        block = request.payload.value
 
-        for uuid,block in blocks.items():
-            try:
-                self.process_block(block)
-            except ProvenanceLoopError:
-                # This configuration block came from us. Pay no mind.
-                pass
+        try:
+            self.process_block(block)
+        except ProvenanceLoopError:
+            # This configuration block came from us. Pay no mind.
+            pass
 
         payload = mktl.Payload(value=True)
         return payload

--- a/src/mktl/begin.py
+++ b/src/mktl/begin.py
@@ -23,9 +23,9 @@ def _clear(store):
         existing = _cache[store]
     except KeyError:
         return
-
-    del _cache[store]
-    return existing
+    else:
+        del _cache[store]
+        return existing
 
 
 

--- a/src/mktl/begin.py
+++ b/src/mktl/begin.py
@@ -219,7 +219,11 @@ def refresh(configuration):
                 # No response from this daemon; it's broken somehow. Move on.
                 continue
 
-            hashes = response.payload.value
+            try:
+                hashes = response.payload.value
+            except AttributeError:
+                hashes = None
+
             if hashes is None:
                 # No response available.
                 continue

--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -1213,7 +1213,7 @@ def announce(config, uuid, override=False):
     if override == True:
         block['override'] = True
 
-    payload = protocol.message.Payload(block)
+    payload = protocol.message.Payload(value=block)
     payload.add_origin()
     message = protocol.message.Request('CONFIG', store, payload)
 

--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -1225,7 +1225,11 @@ def announce(config, uuid, override=False):
         except TimeoutError:
             continue
 
-        error = payload.error
+        try:
+            error = payload.error
+        except AttributeError:
+            continue
+
         if error is None or error == '':
             continue
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -533,7 +533,7 @@ class RequestServer(protocol.request.Server):
 
         configuration = config.get(store)
         configuration = configuration._by_uuid
-        payload = protocol.message.Payload(configuration)
+        payload = protocol.message.Payload(value=configuration)
         return payload
 
 
@@ -549,7 +549,7 @@ class RequestServer(protocol.request.Server):
                 store = None
 
         hashes = config.get_hashes(store)
-        payload = protocol.message.Payload(hashes)
+        payload = protocol.message.Payload(value=hashes)
         return payload
 
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -398,7 +398,7 @@ class Daemon:
                 continue
 
             item = self.store[key]
-            payload = protocol.message.Payload(initial)
+            payload = protocol.message.Payload(value=initial)
             request = protocol.message.Request('SET', item.full_key, payload)
             item.req_initialize(request)
 
@@ -483,7 +483,7 @@ class RequestServer(protocol.request.Server):
             for uuid in uuids:
                 response[uuid] = config[uuid]
 
-        payload = protocol.message.Payload(response)
+        payload = protocol.message.Payload(value=response)
         return payload
 
 
@@ -566,7 +566,7 @@ class RequestServer(protocol.request.Server):
             store = None
 
         hashes = config.get_hashes(store)
-        payload = protocol.message.Payload(hashes)
+        payload = protocol.message.Payload(value=hashes)
         return payload
 
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -755,8 +755,13 @@ def _save_persistent(item, *args, **kwargs):
     by_prefix = dict()
     payload = item.to_payload()
 
-    if payload.bulk is not None:
-        by_prefix['bulk'] = payload.bulk
+    try:
+        bulk = payload.bulk
+    except AttributeError:
+        pass
+    else:
+        if bulk is not None:
+            by_prefix['bulk'] = bulk
 
     by_prefix[''] = payload.encapsulate()
 

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -190,6 +190,13 @@ class Daemon:
         except KeyError:
             raise KeyError("this daemon is not authoritative for the key '%s'" %(key))
 
+
+        # Allow for the possibility that a daemon is establishing an
+        # authoritative item where before a default item was created
+        # by a just-in-time process. We cannot assume the daemon is
+        # using a default Item instance; if it was, it would be enough
+        # to set the .authoritative attribute and move on.
+
         existing = self.store._items[key]
 
         if existing is not None:
@@ -510,6 +517,8 @@ class RequestServer(protocol.request.Server):
         else:
             return getter(request)
 
+        # Look up the conventional req_get() method for this item.
+
         store, key = request.target.split('.', 1)
 
         if store != self.daemon.store.name:
@@ -522,8 +531,16 @@ class RequestServer(protocol.request.Server):
         else:
             raise KeyError('this daemon does not contain ' + repr(key))
 
+        # There's an argument for optimizing the behavior here by storing
+        # the getter reference to prevent the need to look it up all over
+        # again. There's a bootstrapping problem though, and Item instances
+        # can be replaced in authoritative daemons partway through the
+        # initialization process.
+
+        # This suggested optimization also doesn't buy us a measurable
+        # improvement in transactions per second.
+
         getter = self.daemon.store[key].req_get
-        self._getters[request.target] = getter
         return getter(request)
 
 

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -203,12 +203,15 @@ class Item:
             This is the inverse of :func:`to_payload`.
         """
 
-        if payload.bulk is not None:
+        try:
+            bulk = payload.bulk
+        except AttributeError:
+            bulk = None
+
+        if bulk is not None:
 
             if numpy is None:
                 raise ImportError('numpy module not available')
-
-            bulk = payload.bulk
 
             shape = payload.shape
             dtype = payload.dtype
@@ -287,7 +290,7 @@ class Item:
         elif refresh == False:
             request = protocol.message.Request('GET', self.full_key)
         elif refresh == True:
-            payload = protocol.message.Payload(None, refresh=True)
+            payload = protocol.message.Payload(refresh=True)
             request = protocol.message.Request('GET', self.full_key, payload)
         else:
             raise TypeError('refresh argument must be a boolean')
@@ -440,7 +443,12 @@ class Item:
         changed = False
 
         if repeat == False:
-            if payload.bulk is None:
+            try:
+                bulk = payload.bulk
+            except AttributeError:
+                bulk = None
+
+            if bulk is None:
                 changed = self._daemon_value != new_value
             else:
                 if self._daemon_value is None and new_value is not None:

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -301,7 +301,11 @@ class Item:
         if response is None:
             raise RuntimeError('GET failed: no response to request')
 
-        error = response.payload.error
+        try:
+            error = response.payload.error
+        except AttributeError:
+            error = None
+
         if error is not None and error != '':
             e_type = error['type']
             e_text = error['text']
@@ -719,7 +723,11 @@ class Item:
         if response is None:
             raise RuntimeError("SET of %s failed: no response to request" % (self.key))
 
-        error = response.payload.error
+        try:
+            error = response.payload.error
+        except AttributeError:
+            error = None
+
         if error is not None and error != '':
             e_type = error['type']
             e_text = error['text']
@@ -828,9 +836,15 @@ class Item:
         """
 
         if self.authoritative == True:
-            return self._daemon_value_timestamp
+            timestamp = self._daemon_value_timestamp
         else:
-            return self._value_timestamp
+            timestamp = self._value_timestamp
+
+        if timestamp is None:
+            # This only occurs in startup conditions, but it does occur.
+            timestamp = time.time()
+
+        return timestamp
 
 
     def to_format(self, value):

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -653,7 +653,7 @@ class Item:
         # the contents of the response payload are not inspected.
 
         if response is None:
-            payload = protocol.message.Payload(True)
+            payload = protocol.message.Payload(value=True)
         elif isinstance(response, protocol.message.Payload):
             payload = response
         else:
@@ -885,11 +885,11 @@ class Item:
             bulk = value.tobytes()
         except AttributeError:
             bulk = None
-            payload = protocol.message.Payload(value, timestamp)
+            payload = protocol.message.Payload(value=value, time=timestamp)
         else:
             shape = value.shape
             dtype = str(value.dtype)
-            payload = protocol.message.Payload(None, timestamp, bulk=bulk, shape=shape, dtype=dtype)
+            payload = protocol.message.Payload(time=timestamp, bulk=bulk, shape=shape, dtype=dtype)
 
         return payload
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -8,7 +8,7 @@ import os
 import platform
 import sys
 import threading
-import time as timemodule
+import time
 
 from .. import json
 
@@ -93,7 +93,7 @@ class Message:
         self.payload = payload
         self.prefix = None
         self.target = target
-        self.timestamp = timemodule.time()
+        self.timestamp = time.time()
 
         self._parts = None
 

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -151,7 +151,10 @@ class Message:
             bulk = None
             payload = b''
         else:
-            bulk = payload.bulk
+            try:
+                bulk = payload.bulk
+            except AttributeError:
+                bulk = None
             payload = payload.encapsulate()
 
         # The absence of the bulk field is the indication that it should
@@ -275,7 +278,10 @@ class Broadcast(Message):
             bulk = None
             payload = b''
         else:
-            bulk = payload.bulk
+            try:
+                bulk = payload.bulk
+            except AttributeError:
+                bulk = None
             payload = payload.encapsulate()
 
         # The prefix is ignored for broadcast messages; it should not be set.
@@ -449,48 +455,14 @@ class Payload:
 
     omit = set(('bulk', 'omit'))
 
-    def __init__(self, value, time=None, error=None, bulk=None, shape=None, dtype=None, refresh=None, **kwargs):
+    def __init__(self, **kwargs):
         """ Arbitrary keyword arguments are allowed when creating a
-            :class:`Payload` instance, beyond the canonical set; when
-            included, these additional keyword arguments will be assigned
-            directly as attributes for later encapsulation. Any values
+            :class:`Payload` instance, beyond the canonical set; any values
             assigned in this fashion must be serializable as JSON.
         """
 
-        # The use of 'time' as a keyword argument is what's motivating the
-        # weird import of the time module in this file. We want the keyword
-        # arguments to be aligned with the fields in the JSON description
-        # of a payload: value, time, error, etc.
-
-        if time is None:
-            time = timemodule.time()
-
-        if refresh is False:
-            refresh = None
-
-        # We expect the canonical arguments to all be set all the time,
-        # even if their value is None. That's why they're not rolled up
-        # into the kwargs catch-all.
-
-        self.bulk = bulk
-        self.dtype = dtype
-        self.error = error
-        self.refresh = refresh
-        self.shape = shape
-        self.time = time
-        self.value = value
-
-        if not kwargs:
-            # This is the average case. Faster to check this one condition
-            # and return than to drop out of the next two conditions.
-            return
-
         if 'omit' in kwargs:
             raise ValueError("cannot assign 'omit' to a Payload")
-
-        # Allow additional arbitrary fields in the payload. We are assuming
-        # the caller knows what they are doing, and that these additional
-        # fields can be serialized as JSON.
 
         for key,value in kwargs.items():
             setattr(self, key, value)

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -494,9 +494,11 @@ class Payload:
             if key in self.omit:
                 continue
 
-            # Do not include attributes that are just 'None'. This may be
-            # premature optimization, but it seems silly to put a bunch of
-            # extra bytes on the wire when it conveys no additional information.
+            # Do not include attributes that are None. This may be premature
+            # optimization, but it seems silly to put extra bytes on the wire
+            # when it conveys no additional information.
+
+            # Only the 'value' attribute will be put on the wire if it is None.
 
             # It's faster to check the key against 'value' repeatedly than
             # to build a separate set of includes and only assign those

--- a/src/mktl/protocol/request.py
+++ b/src/mktl/protocol/request.py
@@ -94,8 +94,7 @@ class Client:
             # Fingers crossed that this works:
             response_id = parts[1]
 
-            payload = message.Payload(None)
-            payload.error = error
+            payload = message.Payload(error=error)
             response = message.Message('REP', '???', payload, response_id)
 
 
@@ -396,8 +395,7 @@ class Server:
 
         if error is not None:
             if payload is None:
-                payload = message.Payload(None)
-                payload.error = error
+                payload = message.Payload(error=error)
             elif payload.error is None:
                 payload.error = error
 

--- a/tests/protocol/test_payload.py
+++ b/tests/protocol/test_payload.py
@@ -7,16 +7,24 @@ def test_basics():
     start = time.time()
 
     for test_value in (44, True, None, 35.5, (1,2,3), {1: 'one'}, 'string'):
-        payload = mktl.protocol.message.Payload(test_value)
+        payload = mktl.protocol.message.Payload(value=test_value, time=time.time())
         assert payload.value is test_value
         assert payload.time > start
-        assert payload.bulk == None
-        assert payload.dtype == None
-        assert payload.error == None
-        assert payload.refresh == None
-        assert payload.shape == None
-        ## Pull request is pending
-        ##assert payload.reply == True
+
+        # The 'new' Payload only has attributes for the keyword arguments
+        # set when it is instantiated.
+
+        with pytest.raises(AttributeError):
+            payload.bulk
+        with pytest.raises(AttributeError):
+            payload.dtype
+        with pytest.raises(AttributeError):
+            payload.error
+        with pytest.raises(AttributeError):
+            payload.refresh
+        with pytest.raises(AttributeError):
+            payload.shape
+
         payload.encapsulate()
 
 
@@ -24,7 +32,7 @@ def test_encapsulate():
 
     test_value = 44
     for test_value in (44, True, None, 35.5, [1,2,3], 'string'):
-        payload = mktl.protocol.message.Payload(test_value)
+        payload = mktl.protocol.message.Payload(value=test_value, time=time.time())
 
         encapsulated = payload.encapsulate()
         assert isinstance(encapsulated, bytes)
@@ -37,7 +45,7 @@ def test_encapsulate():
         assert decoded['value'] == test_value
 
 
-    bad_payload = mktl.protocol.message.Payload({None: 'none'})
+    bad_payload = mktl.protocol.message.Payload(value={None: 'none'})
 
     with pytest.raises(TypeError):
         bad_payload.encapsulate()
@@ -45,7 +53,7 @@ def test_encapsulate():
 
 def test_kwargs():
 
-    payload = mktl.protocol.message.Payload('something', testing='testing')
+    payload = mktl.protocol.message.Payload(value='something', testing='testing', time=time.time())
     assert payload.testing == 'testing'
 
     encapsulated = payload.encapsulate()
@@ -65,7 +73,7 @@ def test_kwargs():
 
 def test_origin():
 
-    payload = mktl.protocol.message.Payload('something')
+    payload = mktl.protocol.message.Payload(payload='something')
     payload.add_origin()
 
     encapsulated = payload.encapsulate()


### PR DESCRIPTION
The initial implementation of the Payload class was more like the Message class, with defined standard attributes that were always present. Once the Payload class was expanded to handle arbitrary keyword arguments it wasn't clear why the canonical attributes were necessary in all cases; in some situations they were an active detriment, and resulted in extra JSON serialization where the extra fields had no meaning-- like an empty 'value' assignment.

This pull request eliminates the standard attributes from the Payload, instead only using arbitrary keyword arguments. The absence of the canonical attributes means that several "is None" checks had to be converted to try/except blocks, but otherwise the flow is the same.