### PR TITLE
Rearrange item and store documentation

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -53,31 +53,3 @@ All other client operations, such as getting and setting item values, are
 handled via the :class:`mktl.Item` instance.
 
 .. autofunction:: mktl.get
-
-
-The Store class
----------------
-
-The :class:`mktl.Store` class is primarily an organizational structure,
-providing a dictionary-like interface to retrieve :class:`mktl.Item` instances.
-
-.. autoclass:: mktl.Store
-   :members:
-
-
-The Item class
---------------
-
-The bulk of the client interactions will occur with the :class:`mktl.Item`
-class. In addition to the methods described here an :class:`mktl.Item` instance
-can be used with Python operators, such as addition/concatenation or
-multiplication.
-The behavior of an :class:`mktl.Item` when used in this fashion will be aligned
-with the native Python binary type for the item value; for example, if an
-item test.BAR has an integer value 12, ``test.BAR + 5`` will return the integer
-value 17. If test.BAR is instead the string value '12', the same operation
-would raise a TypeError exception; however, ``test.BAR + '5'`` would return
-the string value '125', just like you would expect for string concatenation.
-
-.. autoclass:: mktl.Item
-   :members: formatted, get, quantity, register, set, subscribe, value

--- a/doc/daemon.rst
+++ b/doc/daemon.rst
@@ -43,33 +43,15 @@ initialization steps must occur such as defining a common communication point
 to access a hardware controller, or whether the initial state of a set of
 items needs to be manipulated before proceeding with routine operations.
 
-In nearly all cases the developer will need to create a custom
-:class:`mktl.Daemon` subclass to satisfy the operational goals of an
-individual daemon.
+In most cases the developer will need to create a custom :class:`mktl.Daemon`
+subclass to satisfy the operational goals of an application. Likewise, in most
+cases the developer will need to create custom :class:`mktl.Item` subclasses
+to implement application-specific behavior, with special attention paid to the
+:ref:`specific methods to override <item_subclassing>`, and
+:ref:`additional methods useful in a daemon context <item_daemon_methods>`.
 
 .. autoclass:: mktl.Daemon
    :members:
-
-
-The Item class, expanded
-------------------------
-
-The bulk of any daemon-specific logic will occur in :class:`mktl.Item`
-subclasses. This is where requests get handled, where data gets interpreted,
-where logic is defined that could span items within and without the boundaries
-of the containing :class:`mktl.Daemon`.
-
-The key methods to override when implementing custom behavior are
-:func:`mktl.Item.perform_get`,
-:func:`mktl.Item.perform_set`, and
-:func:`mktl.Item.validate`.
-In addition, :func:`mktl.Item.req_poll` will be of interest, used in combination
-with :func:`mktl.Item.register`, and the :py:attr:`mktl.Item.value` property,
-as well as the :py:attr:`mktl.Item.formatted` and :py:attr:`mktl.Item.quantity`
-variants, to explicitly set a new item value.
-
-.. autoclass:: mktl.Item
-   :members: from_payload, perform_get, perform_set, poll, publish, req_get, req_poll, req_set, to_payload, validate
 
 
 Configuration management

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,8 @@ be expert mKTL maintainers in order to successfully develop an application.
 
    client
    daemon
+   store
+   item
    examples
    executables
    configuration

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,10 +29,10 @@ be expert mKTL maintainers in order to successfully develop an application.
    :maxdepth: 2
 
    overview
-   client
-   daemon
    store
    item
+   daemon
+   client
    examples
    executables
    configuration

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,19 +29,19 @@ be expert mKTL maintainers in order to successfully develop an application.
    :maxdepth: 2
 
    overview
+   client
+   daemon
    store
    item
-   daemon
-   client
    examples
    executables
    configuration
    built_ins
    protocol
    protocol_interface
-   governance
-   code_of_conduct
    heritage
+   code_of_conduct
+   governance
    glossary
 
 Indices and tables

--- a/doc/item.rst
+++ b/doc/item.rst
@@ -1,0 +1,59 @@
+
+The Item class
+==============
+
+.. autoclass:: mktl.Item
+
+   The bulk of mKTL interactions involve the :class:`mktl.Item` class. In
+   addition to the methods described here an :class:`mktl.Item` instance
+   can be used with Python operators, such as addition/concatenation or
+   multiplication.
+
+   The behavior of an :class:`mktl.Item` when used in this fashion will be
+   aligned with the native Python binary type for the item value; for example,
+   if an item test.BAR has an integer value 12, ``test.BAR + 5`` will return
+   the integer value 17. If test.BAR is instead the string value '12', the
+   same operation would raise a TypeError exception; however, ``test.BAR + '5'``
+   would return the string value '125', just like you would expect for string
+   concatenation. In-place operators will set the current value of the item.
+
+   Three properties allow unified access to getting and setting an item's
+   value, regardless of whether the local application is authoritative for
+   that specific item. The use of properties implies default behavior for
+   both :func:`get` and :func:`set` in a client context, and for :func:`publish`
+   in a daemon context.
+
+   The use of these properties is encouraged as the preferred approach to
+   getting and setting item values.
+
+   .. automethod:: value
+   .. automethod:: formatted
+   .. automethod:: quantity
+
+   Outside the use of properties, three key methods are likely to be used
+   in a client context:
+
+   .. automethod:: get
+   .. automethod:: set
+   .. automethod:: register
+
+   All of the client functionality remains unchanged when an :class:`Item`
+   is used in a daemon context. Additional methods have meaning when a
+   daemon is authoritative for an item:
+
+   .. automethod:: from_payload
+   .. automethod:: poll
+   .. automethod:: publish
+   .. automethod:: req_get
+   .. automethod:: req_poll
+   .. automethod:: req_set
+   .. automethod:: to_payload
+
+   Some of the daemon-specific methods are intended to be overridden as
+   part of implementing custom, application-specific logic:
+
+   .. automethod:: perform_get
+   .. automethod:: perform_set
+   .. automethod:: validate
+
+   :members: formatted, get, quantity, register, set, subscribe, value

--- a/doc/item.rst
+++ b/doc/item.rst
@@ -1,3 +1,4 @@
+.. _item:
 
 The Item class
 ==============

--- a/doc/item.rst
+++ b/doc/item.rst
@@ -26,9 +26,9 @@ The Item class
    The use of these properties is encouraged as the preferred approach to
    getting and setting item values.
 
-   .. automethod:: value
-   .. automethod:: formatted
-   .. automethod:: quantity
+   .. autoproperty:: value
+   .. autoproperty:: formatted
+   .. autoproperty:: quantity
 
    Outside the use of properties, three key methods are likely to be used
    in a client context:
@@ -55,5 +55,3 @@ The Item class
    .. automethod:: perform_get
    .. automethod:: perform_set
    .. automethod:: validate
-
-   :members: formatted, get, quantity, register, set, subscribe, value

--- a/doc/item.rst
+++ b/doc/item.rst
@@ -21,37 +21,45 @@ The Item class
    value, regardless of whether the local application is authoritative for
    that specific item. The use of properties implies default behavior for
    both :func:`get` and :func:`set` in a client context, and for :func:`publish`
-   in a daemon context.
-
-   The use of these properties is encouraged as the preferred approach to
-   getting and setting item values.
+   in a daemon context. The use of these properties is encouraged as the
+   preferred approach to getting and setting item values; any functionality
+   beyond the default behavior requires using the methods directly.
 
    .. autoproperty:: value
    .. autoproperty:: formatted
    .. autoproperty:: quantity
 
-   Outside the use of properties, three key methods are likely to be used
-   in a client context:
-
    .. automethod:: get
    .. automethod:: set
    .. automethod:: register
 
+   .. _item_daemon_methods:
+
    All of the client functionality remains unchanged when an :class:`Item`
-   is used in a daemon context. Additional methods have meaning when a
-   daemon is authoritative for an item:
+   is used in a daemon context. The following methods have utility when
+   a daemon is authoritative for an item.
 
    .. automethod:: from_payload
    .. automethod:: poll
    .. automethod:: publish
-   .. automethod:: req_get
-   .. automethod:: req_poll
-   .. automethod:: req_set
    .. automethod:: to_payload
 
+   .. _item_subclassing:
+
    Some of the daemon-specific methods are intended to be overridden as
-   part of implementing custom, application-specific logic:
+   part of implementing custom, application-specific logic. It may not
+   be necessary to override all of these methods depending on the needs
+   of the application.
 
    .. automethod:: perform_get
    .. automethod:: perform_set
    .. automethod:: validate
+
+   The *req_\*()* set of methods can be overridden, but for nearly all
+   applications their use is strictly internal and further customization
+   should not be necessary.
+
+   .. automethod:: req_get
+   .. automethod:: req_poll
+   .. automethod:: req_set
+

--- a/doc/item.rst
+++ b/doc/item.rst
@@ -34,6 +34,7 @@ The Item class
    .. automethod:: set
    .. automethod:: register
 
+
    .. _item_daemon_methods:
 
    All of the client functionality remains unchanged when an :class:`Item`
@@ -44,6 +45,7 @@ The Item class
    .. automethod:: poll
    .. automethod:: publish
    .. automethod:: to_payload
+
 
    .. _item_subclassing:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -33,4 +33,4 @@ From a high level view, an mKTL client solely interacts with mKTL items, contain
 
 .. mermaid:: overview_daemon.mmd
 
-The perspective from an mKTL daemon is the mirror image, with daemons likewise not requiring any direct interactions with the protocol or transport, though again a daemon could bypass all interface code as long as it adheres to :ref:`mKTL standards <protocol>`.
+The perspective from an mKTL daemon is the mirror image, with daemons likewise not requiring any direct interactions with the protocol or transport, though again a daemon could bypass all interface code as long as it adheres to :ref:`the mKTL protocol <protocol>`.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -19,13 +19,13 @@ The protocol provides:
 Core concepts
 -------------
 
-mKTL organizes commands and telemetry using a hierarchical namespace composed of stores and items. A *store* is a collection of *items*. It is effectively an associative array, providing little additional functionality beyond being a container. A store will have a unique name within its local namespace.
+mKTL organizes commands and telemetry using a hierarchical namespace composed of :ref:`stores <store>` and :ref:`items <item>`. A store is a collection of items. It is effectively an associative array, providing little additional functionality beyond being a container. A store will have a unique name within its local namespace.
 
-An *item* is the smallest addressable unit in mKTL, a single key/value pair that may correspond to a command, a configuration parameter, a telemetry value, an image buffer, and so on. Examples of items might include a power on/off control, a device operating mode, a temperature reading, a motor position, or the most recent image from a detector.
+An item is the smallest addressable unit in mKTL, a single key/value pair that may correspond to a command, a configuration parameter, a telemetry value, an image buffer, and so on. Examples of items might include a power on/off control, a device operating mode, a temperature reading, a motor position, or the most recent image from a detector.
 
-Each item has a *key* that uniquely identifies it within its store; the same item key can be reused in multiple stores. The store name and the item key combine to create the fully qualified key, which uniquely identifies an item within a local mKTL context.
+Each item has a key that uniquely identifies it within its store; the same item key can be reused in multiple stores. The store name and the item key combine to create the fully qualified key, which uniquely identifies an item within a local mKTL context.
 
-A *daemon* is any application that is authoritative for one or more items, meaning, the daemon is responsible for publishing any new values, and for handling any requests to change the value of the item. A *client* is any application that interacts with an item for which it is not authoritative.
+A :ref:`daemon <daemon>` is any application that is authoritative for one or more items, meaning, the daemon is responsible for publishing any new values, and for handling any requests to change the value of the item. A :ref:`client <client>` is any application that interacts with an item for which it is not authoritative.
 
 .. mermaid:: overview_client.mmd
 

--- a/doc/store.rst
+++ b/doc/store.rst
@@ -1,0 +1,7 @@
+.. _store:
+
+The Store class
+===============
+
+.. autoclass:: mktl.Store
+   :members:

--- a/src/mktl/item.py
+++ b/src/mktl/item.py
@@ -519,6 +519,18 @@ class Item:
             to call it separately. If *prime* is set to True the callback will
             be invoked using the current value of the item, if any, before
             returning; no priming call will occur if the item has no value.
+
+            A callback method should expect three arguments: a reference to
+            the :class:`Item` from whence the callback originated, the new
+            value for the item, and the timestamp associated with the new
+            value. For example::
+
+              def my_callback(item, new_value, new_timestamp):
+
+            Callback methods should strive to be lightweight in terms of
+            their execution time; any callbacks registered for an item will
+            be called in series, and there are no provisions for shortening
+            the queue if a backlog occurs.
         """
 
         if callable(method):


### PR DESCRIPTION
Splitting the documentation for the Item class across multiple pages was awkward, and threw errors every time the documentation was built. This pull requests puts the Item and Store class into dedicated pages and removes the client-specific and daemon-specific documentation for those classes from the client and daemon pages.