### PR TITLE
Quick fixes

### DIFF
--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -57,12 +57,20 @@ def main():
                 logger.warning("HASH request from %s:%d failed" % (address, port))
                 continue
 
-            hashes = payload.value
+            if payload:
+                hashes = payload.value
+            else:
+                hashes = None
 
             if hashes is None:
                 # Error requesting the hashes.
                 logger.warning("HASH request from %s:%d failed" % (address, port))
-                error = payload.error
+
+                if payload:
+                    error = payload.error
+                else:
+                    error = None
+
                 if error:
                     e_type = error['type']
                     e_text = error['text']

--- a/src/mktl/begin.py
+++ b/src/mktl/begin.py
@@ -56,14 +56,20 @@ def discover(*targets):
         except:
             continue
 
-        hashes = payload.value
+        if payload:
+            hashes = payload.value
+        else:
+            hashes = dict()
 
         for store in hashes.keys():
             key = store + '._config'
             request = protocol.message.Request('GET', key)
             payload = protocol.request.send(address, port, request)
 
-            blocks = payload.value
+            if payload:
+                blocks = payload.value
+            else:
+                blocks = None
 
             if blocks:
                 configuration = config.get(store)

--- a/src/mktl/protocol/publish.py
+++ b/src/mktl/protocol/publish.py
@@ -317,7 +317,7 @@ class Server:
         except AttributeError:
             self.broadcasts = queue.Queue()
 
-        internal = "inproc://publish.Server.signal:%d" % (port)
+        internal = "inproc://publish.Server.signal:%d" % (self.port)
         self.broadcast_address = internal
         self.broadcast_receive = zmq_context.socket(zmq.PAIR)
         self.broadcast_receive.bind(internal)


### PR DESCRIPTION
I was running some tests between different networked hosts, and a few minor bugs were uncovered. Some related to the handling of an empty payload on an error condition, another was the proper assignment of a PUB port number in the event that no port number was initially assigned (i.e., this is a newly running daemon with no cached port number).