### PR TITLE
Registry as daemon

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -461,9 +461,11 @@ running configuration.
 
 Daemons are expected to self-announce on startup,
 which involves discovering local registries, and pushing the description of
-the daemon's authoritative items to any discovered registries; the registry
-will reconcile the description against what it already has cached, and will
-reject any announcement that introduces a conflict.
+the daemon's authoritative items to any discovered registries; the daemon
+will issue a SET request to the registry's _config item to initiate further
+processing. The registry will reconcile the new description against what it
+already has cached, and will reject any announcement that introduces a
+conflict.
 
 There are four shared secrets used in the discovery exchange:
 

--- a/doc/protocol_discover_daemon.mmd
+++ b/doc/protocol_discover_daemon.mmd
@@ -7,4 +7,4 @@ sequenceDiagram
     Registry->>-Daemon: Try port 10234
 
     Daemon->>+Registry: SET: _config
-    Registry->>-Daemon: REP: JSON payload
+    Registry->>-Daemon: REP:

--- a/doc/protocol_discover_daemon.mmd
+++ b/doc/protocol_discover_daemon.mmd
@@ -6,5 +6,5 @@ sequenceDiagram
     Daemon->>+Registry: Hello?
     Registry->>-Daemon: Try port 10234
 
-    Daemon->>+Registry: SET: store1._config
+    Daemon->>+Registry: SET: _config
     Registry->>-Daemon: REP: JSON payload

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -63,18 +63,7 @@ main.shutdown = threading.Event()
 def generate_description():
 
     items = dict()
-
-    items['daemon_count'] = dict()
-    items['daemon_count']['description'] = 'Quantity of active daemons seen by this registry.'
-    items['daemon_count']['type'] = 'numeric'
-    items['daemon_count']['initial'] = 0
-    items['daemon_count']['settable'] = False
-
-    items['log'] = dict()
-    items['log']['description'] = 'Log message describing recent events.'
-    items['log']['initial'] = ''
-    items['log']['settable'] = False
-
+    # Not adding any custom items just yet.
     return items
 
 
@@ -96,10 +85,21 @@ class RegistryDaemon(mktl.Daemon):
 
     def setup(self):
 
-        # This would normally be a call to self.add_get_handler() but
-        # the _config concept is not a fully qualified item.
+        # The comment below for accept_requests() explains the motivation
+        # for making this assignment directly. There is no similar top-level
+        # assignment for _hash because it is handled by the base Daemon class.
 
         self.rep._req_set_handlers['_config'] = self.req_set_config
+
+
+    def accept_requests(self, store):
+        # Normally this would be a call to self.add_get_handler(),
+        # but that method has a safety check verifying the local
+        # store has a matching item-- that is not the case for the
+        # registry. So the handler dictionary is manipulated directly.
+
+        key = store + '._config'
+        self.rep._req_get_handlers[key] = self.req_get_config
 
 
     def check_keys(self, new, override):
@@ -306,8 +306,7 @@ class RegistryDaemon(mktl.Daemon):
         # a block at all implies we must be ready to answer queries for
         # that store.
 
-        key = store + '._config'
-        self.rep._req_get_handlers[key] = self.req_get_config
+        self.accept_requests(store)
 
         config = mktl.config.get(store)
 

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -305,11 +305,10 @@ class Registry:
         store = new['store']
         store = store.lower()
 
-        # Dynamically update the request handling to know how to handle
-        # requests for the configuration for this store. Regardless of
-        # how we received a configuration block, the fact that we have
-        # a block at all implies we must be ready to answer queries for
-        # that store.
+        # Dynamically update the request handling to accept GET requests for
+        # the configuration for this store. Regardless of how we received a
+        # configuration block, the fact that we have a block at all implies
+        # we must be ready to answer queries for that store.
 
         self.accept_requests(store)
 
@@ -332,7 +331,7 @@ class Registry:
         except KeyError:
             override = False
         else:
-            # Won't be needing that going forward. The presence of an
+            # Won't be needing this flag going forward. The presence of an
             # override flag is only relevant right now, as part of these
             # checks being performed right here for an 'announce' operation.
             del new['override']
@@ -424,8 +423,9 @@ class Registry:
 
 
     def req_get_config(self, request):
-        """ We are expecting queries for hash and configuration data, aimed
-            at special 'store._config' items.
+        """ Handle all GET requests for 'store._config' items, regardless of
+            which store it is. Requests for unknown stores will not reach this
+            point.
         """
 
         target = request.target
@@ -443,8 +443,8 @@ class Registry:
 
 
     def req_set_config(self, request):
-        """ We are expecting queries for configuration data, aimed
-            at specially named built-in keys.
+        """ Handle all SET requests for the '_config' key. These requests
+            are part of a daemon's announce operation.
         """
 
         # We could be inspecting the request.target value to ensure it

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -31,19 +31,22 @@ def main():
     # case where the caller specifies -h on the command line.
 
     config = parse_command_line()
-    store = 'registry:' + socket.getfqdn()
+    main.hostname = socket.getfqdn()
+    store = 'registry:' + main.hostname
 
     description = generate_description()
     mktl.config.authoritative(store, store, description)
 
-    daemon = RegistryDaemon(store)
-    beacon = mktl.protocol.discover.Server(daemon.req.port)
+    daemon = RegistryDaemon(store, store, override=True)
+    beacon = mktl.protocol.discover.Server(daemon.rep.port)
 
     # Run discovery once upon startup, rely on daemon announcements to
     # learn of any additions to the local network.
 
-    main.discover_daemons()
+    daemon.discover_daemons()
 
+
+    delay = 30
     while True:
         try:
             main.shutdown.wait(delay)
@@ -52,7 +55,7 @@ def main():
 
 
 
-
+main.hostname = None
 main.shutdown = threading.Event()
 
 
@@ -61,7 +64,7 @@ def generate_description():
 
     items = dict()
 
-    items['daemons'] = dict()
+    items['daemon_count'] = dict()
     items['daemon_count']['description'] = 'Quantity of active daemons seen by this registry.'
     items['daemon_count']['type'] = 'numeric'
     items['daemon_count']['initial'] = 0
@@ -72,6 +75,7 @@ def generate_description():
     items['log']['initial'] = ''
     items['log']['settable'] = False
 
+    return items
 
 
 def parse_command_line():
@@ -174,8 +178,8 @@ class RegistryDaemon(mktl.Daemon):
         """
 
         local_provenance = dict()
-        local_provenance['hostname'] = self.hostname
-        local_provenance['rep'] = self.port
+        local_provenance['hostname'] = main.hostname
+        local_provenance['rep'] = self.rep.port
 
         if mktl.config.contains_provenance(block, local_provenance):
             raise ProvenanceLoopError('circular provenance detected')
@@ -279,11 +283,16 @@ class RegistryDaemon(mktl.Daemon):
                 if blocks:
                     for uuid,block in blocks.items():
                         block['override'] = True
-                        self.process_block(block)
+                        try:
+                            self.process_block(block)
+                        except ProvenanceLoopError:
+                            # This is us, discovering ourselves.
+                            pass
 
 
     def process_block(self, new):
 
+        print('processing: ' + repr(new))
         store = new['store']
         config = mktl.config.get(store)
 
@@ -387,7 +396,7 @@ class RegistryDaemon(mktl.Daemon):
         # Now that all the checks have passed it's time to update the local
         # cache of configuration data.
 
-        mktl.config.add_provenance(new, self.hostname, self.port)
+        mktl.config.add_provenance(new, main.hostname, self.rep.port)
         port = new['provenance'][0]['rep']
         host = new['provenance'][0]['hostname']
 

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -33,7 +33,7 @@ def main():
     description = generate_description()
     mktl.config.authoritative(store, store, description)
 
-    daemon = RegistryDaemon(store, alias=store, override=True)
+    daemon = Daemon(store, alias=store, override=True)
 
     # Run discovery once upon startup, rely on daemon announcements to
     # learn of any additions to the local network.
@@ -464,7 +464,7 @@ class Registry:
 
 
 
-class RegistryDaemon(mktl.Daemon):
+class Daemon(mktl.Daemon):
 
     def setup(self):
 
@@ -486,7 +486,7 @@ class RegistryDaemon(mktl.Daemon):
         self.registry.setup_final()
 
 
-# end of class RegistryDaemon
+# end of class Daemon
 
 
 

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -37,13 +37,13 @@ def main():
     description = generate_description()
     mktl.config.authoritative(store, store, description)
 
-    daemon = RegistryDaemon(store, store, override=True)
-    beacon = mktl.protocol.discover.Server(daemon.rep.port)
+    registry = Registry(store)
+    beacon = mktl.protocol.discover.Server(registry.daemon.rep.port)
 
     # Run discovery once upon startup, rely on daemon announcements to
     # learn of any additions to the local network.
 
-    daemon.discover_daemons()
+    registry.discover_daemons()
 
 
     delay = 30
@@ -81,15 +81,16 @@ def parse_command_line():
 
 
 
-class RegistryDaemon(mktl.Daemon):
+class Registry:
 
-    def setup(self):
+    def __init__(self, store):
+        self.daemon = RegistryDaemon(store, alias=store, override=True)
 
-        # The comment below for accept_requests() explains the motivation
+        # The comment for Registry.accept_requests() explains the motivation
         # for making this assignment directly. There is no similar top-level
         # assignment for _hash because it is handled by the base Daemon class.
 
-        self.rep._req_set_handlers['_config'] = self.req_set_config
+        self.daemon.rep._req_set_handlers['_config'] = self.req_set_config
 
 
     def accept_requests(self, store):
@@ -99,7 +100,7 @@ class RegistryDaemon(mktl.Daemon):
         # registry. So the handler dictionary is manipulated directly.
 
         key = store + '._config'
-        self.rep._req_get_handlers[key] = self.req_get_config
+        self.daemon.rep._req_get_handlers[key] = self.req_get_config
 
 
     def check_keys(self, new, override):
@@ -179,7 +180,7 @@ class RegistryDaemon(mktl.Daemon):
 
         local_provenance = dict()
         local_provenance['hostname'] = main.hostname
-        local_provenance['rep'] = self.rep.port
+        local_provenance['rep'] = self.daemon.rep.port
 
         if mktl.config.contains_provenance(block, local_provenance):
             raise ProvenanceLoopError('circular provenance detected')
@@ -410,7 +411,7 @@ class RegistryDaemon(mktl.Daemon):
         # Now that all the checks have passed it's time to update the local
         # cache of configuration data.
 
-        mktl.config.add_provenance(new, main.hostname, self.rep.port)
+        mktl.config.add_provenance(new, main.hostname, self.daemon.rep.port)
         port = new['provenance'][0]['rep']
         host = new['provenance'][0]['hostname']
 
@@ -457,6 +458,17 @@ class RegistryDaemon(mktl.Daemon):
         payload = mktl.Payload(value=True)
         return payload
 
+
+# end of class Registry
+
+
+
+class RegistryDaemon(mktl.Daemon):
+
+    def setup(self):
+
+        # Not doing anything just yet.
+        pass
 
 # end of class RegistryDaemon
 

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -128,6 +128,8 @@ class Registry:
 
         items = new['items']
         uuid = new['uuid']
+        new_port = new['provenance'][0]['rep']
+        new_host = new['provenance'][0]['hostname']
         to_remove = set()
 
         for old_uuid in config.uuids():
@@ -138,6 +140,8 @@ class Registry:
                 continue
 
             old = config[old_uuid]
+            old_port = old['provenance'][0]['rep']
+            old_host = old['provenance'][0]['hostname']
             running = None
 
             old_items = old['items']
@@ -149,8 +153,6 @@ class Registry:
 
                         if running == True:
                             alias = old['alias']
-                            old_port = old['provenance'][0]['rep']
-                            old_host = old['provenance'][0]['hostname']
                             raise RuntimeError("%s contains %s, and is running at %s:%s" % (alias, key, old_host, old_port))
                         else:
                             # Override requested, and the old daemon is not
@@ -160,9 +162,7 @@ class Registry:
 
                     else:
                         alias = new['alias']
-                        port = new['provenance'][0]['rep']
-                        host = new['provenance'][0]['hostname']
-                        logger.error("reject: %s from %s:%s (%s)" % (alias, host, port, uuid))
+                        logger.error("reject: %s from %s:%s (%s)" % (alias, new_host, new_port, uuid))
                         raise KeyError('key in new configuration block conflicts with an existing key: ' + key)
 
         # This set will be empty unless overrides were requested.
@@ -354,6 +354,8 @@ class Registry:
 
         uuid = new['uuid']
         alias = new['alias']
+        new_port = new['provenance'][0]['rep']
+        new_host = new['provenance'][0]['hostname']
 
         try:
             old = config[uuid]
@@ -374,24 +376,20 @@ class Registry:
                     if running == True:
                         old_port = old['provenance'][0]['rep']
                         old_host = old['provenance'][0]['hostname']
-                        new_port = new['provenance'][0]['rep']
-                        new_host = new['provenance'][0]['hostname']
                         logger.error("reject: %s from %s:%s (%s)" % (alias, new_host, new_port, uuid))
                         raise RuntimeError("%s is running at %s:%s" % (alias, old_host, old_port))
 
 
         if old and authoritative == True:
+            old_port = old['provenance'][0]['rep']
+            old_host = old['provenance'][0]['hostname']
+
             # Does the provenance match? If not, we need an override to
             # proceed, but even then we should only proceed if the previous
             # daemon is offline.
 
             match = mktl.config.match_provenance(old['provenance'], new['provenance'])
             if match == False and override == False:
-                old_port = old['provenance'][0]['rep']
-                old_host = old['provenance'][0]['hostname']
-                new_port = new['provenance'][0]['rep']
-                new_host = new['provenance'][0]['hostname']
-
                 logger.error("reject: %s from %s:%s (%s)" % (alias, new_host, new_port, uuid))
                 raise ValueError("%s expected to be running at %s:%s, you are %s:%s" % (alias, old_host, old_port, new_host, new_port))
 
@@ -399,17 +397,13 @@ class Registry:
                 running = self.check_running(old)
 
                 if running == True:
-                    port = old['provenance'][0]['rep']
-                    host = old['provenance'][0]['hostname']
-                    raise ValueError("%s daemon already running at %s:%s" % (alias, host, port))
+                    raise ValueError("%s daemon already running at %s:%s" % (alias, old_host, old_port))
 
                 # Else the local configuration should be updated to reflect
                 # this new configuration block. Remove the old one to streamline
                 # further checks.
 
-                port = old['provenance'][0]['rep']
-                host = old['provenance'][0]['hostname']
-                logger.info("forget: %s from %s:%s (%s)" % (alias, host, port, uuid))
+                logger.info("forget: %s from %s:%s (%s)" % (alias, old_host, old_port, uuid))
                 config.remove(uuid)
 
             # We've already seen a block for this UUID. Accept the new block
@@ -431,10 +425,8 @@ class Registry:
         # cache of configuration data.
 
         mktl.config.add_provenance(new, main.hostname, self.daemon.rep.port)
-        port = new['provenance'][0]['rep']
-        host = new['provenance'][0]['hostname']
 
-        logger.info("remember: %s from %s:%s (%s)" % (alias, host, port, uuid))
+        logger.info("remember: %s from %s:%s (%s)" % (alias, new_host, new_port, uuid))
         config.update(new)
 
 

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -33,12 +33,12 @@ def main():
     description = generate_description()
     mktl.config.authoritative(store, store, description)
 
-    registry = Registry(store)
+    daemon = RegistryDaemon(store, alias=store, override=True)
 
     # Run discovery once upon startup, rely on daemon announcements to
     # learn of any additions to the local network.
 
-    registry.discover_daemons()
+    daemon.registry.discover_daemons()
 
 
     delay = 30
@@ -77,20 +77,21 @@ def parse_command_line():
 
 
 class Registry:
+    """ The registry-specific behavior is in this subclass to sequester it
+        from the rest of the daemon functionality. Normally this wouldn't
+        be necessary if the application behavior was encapsulated in items,
+        but that is not the case for the registry.
+    """
 
-    def __init__(self, store):
-        self.daemon = RegistryDaemon(store, alias=store, override=True)
+    def __init__(self, daemon):
+        self.daemon = daemon
 
-        # The comment for Registry.accept_requests() explains the motivation
-        # for making this assignment directly. There is no similar top-level
-        # assignment for _hash because it is handled by the base Daemon class.
 
-        self.daemon.rep._req_set_handlers['_config'] = self.req_set_config
-
+    def setup_final(self):
         # Establish the broadcast listener last, once the rest of the
         # machinery is up and running and ready to handle requests.
 
-        beacon = mktl.protocol.discover.Server(self.daemon.rep.port)
+        self.beacon = mktl.protocol.discover.Server(self.daemon.rep.port)
 
 
     def accept_requests(self, store):
@@ -467,8 +468,23 @@ class RegistryDaemon(mktl.Daemon):
 
     def setup(self):
 
-        # Not doing anything just yet.
-        pass
+        # The registry-specific functionality is in the Registry class.
+        # It's instantiated as part of the daemon so that any items can
+        # access the registry functionality.
+
+        registry = Registry(self)
+        self.registry = registry
+
+        # The comment for Registry.accept_requests() explains the motivation
+        # for making this assignment directly. There is no similar top-level
+        # assignment for _hash because it is handled by the base Daemon class.
+
+        self.rep._req_set_handlers['_config'] = registry.req_set_config
+
+
+    def setup_final(self):
+        self.registry.setup_final()
+
 
 # end of class RegistryDaemon
 

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -3,12 +3,12 @@
 description = """
 The registry daemon acts as a clearing house for configuration requests;
 when daemons first start running they will seek out any registries on their
-local network and announce configuration updates; any clients broadcasting
-will discover a local registry, and ask for any available configuration
-information.
+local network and announce the configuration for their authoritative items;
+any clients broadcasting will discover a local registry, and ask for any
+available configuration information.
 
-Daemons and clients can both bypass broadcast discovery for a local registry
-if they already know where to find a registry.
+Clients can bypass broadcast discovery for a local registry if they already
+know where to find a registry.
 """
 
 import argparse
@@ -25,10 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 def main():
-
-    # We don't use command line options here, but if we did, they would be
-    # handled in parse_command_line(). At the very least, it handles the
-    # case where the caller specifies -h on the command line.
 
     config = parse_command_line()
     main.hostname = socket.getfqdn()

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -38,7 +38,6 @@ def main():
     mktl.config.authoritative(store, store, description)
 
     registry = Registry(store)
-    beacon = mktl.protocol.discover.Server(registry.daemon.rep.port)
 
     # Run discovery once upon startup, rely on daemon announcements to
     # learn of any additions to the local network.
@@ -91,6 +90,11 @@ class Registry:
         # assignment for _hash because it is handled by the base Daemon class.
 
         self.daemon.rep._req_set_handlers['_config'] = self.req_set_config
+
+        # Establish the broadcast listener last, once the rest of the
+        # machinery is up and running and ready to handle requests.
+
+        beacon = mktl.protocol.discover.Server(self.daemon.rep.port)
 
 
     def accept_requests(self, store):

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -56,6 +56,9 @@ main.shutdown = threading.Event()
 
 
 def generate_description():
+    """ Return a dictionary describing all custom authoritative items
+        provided by the registry.
+    """
 
     items = dict()
     # Not adding any custom items just yet.
@@ -95,18 +98,24 @@ class Registry:
 
 
     def accept_requests(self, store):
+        """ Dynamically establish a handler for future GET requests
+            for a store's configuration.
+        """
+
         # Normally this would be a call to self.add_get_handler(),
         # but that method has a safety check verifying the local
-        # store has a matching item-- that is not the case for the
-        # registry. So the handler dictionary is manipulated directly.
+        # store has a matching item-- that will not be the case for
+        # any store._config reqeusts added at runtime.
+        #
+        # Thus the handler dictionary is manipulated directly.
 
         key = store + '._config'
         self.daemon.rep._req_get_handlers[key] = self.req_get_config
 
 
-    def check_keys(self, new, override):
-        """ Confirm that any keys unique to this new configuration block are
-            not present in any other blocks.
+    def check_duplicates(self, new, override):
+        """ Confirm that any keys in a configuration block are not present
+            in any already known blocks.
         """
 
         store = new['store']
@@ -232,6 +241,10 @@ class Registry:
 
 
     def discover_daemons(self):
+        """ Look for any daemons on the local network; if any are found,
+            request the current configuration for their store, and process
+            that configuration locally.
+        """
 
         discovered = mktl.protocol.discover.search_direct()
 
@@ -298,6 +311,12 @@ class Registry:
 
 
     def process_block(self, new):
+        """ This is the entry point for the handling and future caching of
+            a new configuration block. All calls to the check_*() methods
+            ultimately originate from this method; only after all checks
+            pass will the new configuration block be cached for future
+            reference.
+        """
 
         store = new['store']
         store = store.lower()
@@ -403,10 +422,10 @@ class Registry:
 
         # Reject a configuration block if it contains keys that collide
         # with another block in the cache. Not looking for a return
-        # value from check_keys(), exceptions are raised when there are
-        # problems.
+        # value from check_duplicates(), exceptions are raised when
+        # there are problems.
 
-        self.check_keys(new, override)
+        self.check_duplicates(new, override)
 
         # Now that all the checks have passed it's time to update the local
         # cache of configuration data.

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -27,96 +27,50 @@ logger = logging.getLogger(__name__)
 def main():
 
     # We don't use command line options here, but if we did, they would be
-    # parsed out in the following call. At the very least, it handles the
+    # handled in parse_command_line(). At the very least, it handles the
     # case where the caller specifies -h on the command line.
 
     config = parse_command_line()
-
-
     store = 'registry:' + socket.getfqdn()
 
-    main.daemon = RegistryDaemon(store)
-    main.beacon = mktl.protocol.discover.Server(main.req.port)
+    description = generate_description()
+    mktl.config.authoritative(store, store, description)
 
-    delay = 30
+    daemon = RegistryDaemon(store)
+    beacon = mktl.protocol.discover.Server(daemon.req.port)
+
+    # Run discovery once upon startup, rely on daemon announcements to
+    # learn of any additions to the local network.
+
+    main.discover_daemons()
 
     while True:
-        not_seen = set(main.known)
-        discovered = mktl.protocol.discover.search_direct()
-
-        for seen in discovered:
-            if seen in main.known:
-                not_seen.remove(seen)
-                continue
-
-            # This is a new daemon to us. Request its known hashes, which
-            # also tells us which store names it has access to; cache any/all
-            # configuration blocks discovered in this fashion.
-
-            address,port = seen
-            request = mktl.protocol.message.Request('GET', '_hash')
-            try:
-                payload = mktl.protocol.request.send(address, port, request)
-            except:
-                logger.warning("HASH request from %s:%d failed" % (address, port))
-                continue
-
-            if payload:
-                hashes = payload.value
-            else:
-                hashes = None
-
-            if hashes is None:
-                # Error requesting the hashes.
-                logger.warning("HASH request from %s:%d failed" % (address, port))
-
-                if payload:
-                    error = payload.error
-                else:
-                    error = None
-
-                if error:
-                    e_type = error['type']
-                    e_text = error['text']
-                    e_debug = error['debug']
-                    logger.warning("Remote exception: %s: %s\n%s" % (e_type, e_text, e_debug))
-                continue
-
-            for store in hashes.keys():
-                request = mktl.protocol.message.Request('GET', store + '._config')
-                payload = mktl.protocol.request.send(address, port, request)
-
-                blocks = payload.value
-
-                try:
-                    error = payload.error
-                except AttributeError:
-                    error = None
-
-                if error:
-                    e_type = error['type']
-                    e_text = error['text']
-                    logger.warning("CONFIG request failed: %s: %s" % (e_type, e_text))
-
-                if blocks:
-                    for uuid,block in blocks.items():
-                        block['override'] = True
-                        main.req.process_block(block)
-
-            main.known.add(seen)
-
-        for missed in not_seen:
-            main.known.remove(missed)
-
         try:
             main.shutdown.wait(delay)
         except (KeyboardInterrupt, SystemExit):
             break
 
 
-main.known = set()
+
+
 main.shutdown = threading.Event()
-main.req = None
+
+
+
+def generate_description():
+
+    items = dict()
+
+    items['daemons'] = dict()
+    items['daemon_count']['description'] = 'Quantity of active daemons seen by this registry.'
+    items['daemon_count']['type'] = 'numeric'
+    items['daemon_count']['initial'] = 0
+    items['daemon_count']['settable'] = False
+
+    items['log'] = dict()
+    items['log']['description'] = 'Log message describing recent events.'
+    items['log']['initial'] = ''
+    items['log']['settable'] = False
 
 
 
@@ -134,10 +88,15 @@ def parse_command_line():
 
 
 
-class RequestServer(mktl.protocol.request.Server):
-    """ Subclass the generic :class:mktl.protocol.request.Server`, adding
-        additional logic to locally handle requests.
-    """
+class RegistryDaemon(mktl.Daemon):
+
+    def setup(self):
+
+        # This would normally be a call to self.add_get_handler() but
+        # the _config concept is not a fully qualified item.
+
+        self.rep._req_set_handlers['_config'] = self.req_set_config
+
 
     def check_keys(self, new, override):
         """ Confirm that any keys unique to this new configuration block are
@@ -266,6 +225,63 @@ class RequestServer(mktl.protocol.request.Server):
         return False
 
 
+    def discover_daemons(self):
+
+        discovered = mktl.protocol.discover.search_direct()
+
+        for seen in discovered:
+
+            address,port = seen
+            request = mktl.protocol.message.Request('GET', '_hash')
+            try:
+                payload = mktl.protocol.request.send(address, port, request)
+            except:
+                logger.warning("HASH request from %s:%d failed" % (address, port))
+                continue
+
+            if payload:
+                hashes = payload.value
+            else:
+                hashes = None
+
+            if hashes is None:
+                # Error requesting the hashes.
+                logger.warning("HASH request from %s:%d failed" % (address, port))
+
+                if payload:
+                    error = payload.error
+                else:
+                    error = None
+
+                if error:
+                    e_type = error['type']
+                    e_text = error['text']
+                    e_debug = error['debug']
+                    logger.warning("Remote exception: %s: %s\n%s" % (e_type, e_text, e_debug))
+                continue
+
+            for store in hashes.keys():
+                request = mktl.protocol.message.Request('GET', store + '._config')
+                payload = mktl.protocol.request.send(address, port, request)
+
+                blocks = payload.value
+
+                try:
+                    error = payload.error
+                except AttributeError:
+                    error = None
+
+                if error:
+                    e_type = error['type']
+                    e_text = error['text']
+                    logger.warning("CONFIG request failed: %s: %s" % (e_type, e_text))
+
+                if blocks:
+                    for uuid,block in blocks.items():
+                        block['override'] = True
+                        self.process_block(block)
+
+
     def process_block(self, new):
 
         store = new['store']
@@ -375,65 +391,36 @@ class RequestServer(mktl.protocol.request.Server):
         port = new['provenance'][0]['rep']
         host = new['provenance'][0]['hostname']
 
+        # Dynamically update the request handling to know how to handle
+        # requests for the configuration for this store.
+
+        key = store + '._config'
+        self.rep._req_get_handlers[key] = self.req_get_config
+
         logger.info("remember: %s from %s:%s (%s)" % (alias, host, port, uuid))
         config.update(new)
 
 
-    def req_get(self, request):
+    def req_get_config(self, request):
         """ We are expecting queries for hash and configuration data, aimed
-            at specially named built-in keys '_hash' and '_config'.
+            at special 'store._config' items.
         """
 
         target = request.target
+        store, key = target.split('.', 1)
 
-        if target == '_hash':
-            store = None
-            key = '_hash'
+        try:
+            config = mktl.config.get(store)
+        except KeyError:
+            payload_data = tuple()
         else:
-            store, key = target.split('.', 1)
-            if store == '':
-                store = None
-
-        if key == '_hash':
-            payload_data = mktl.config.get_hashes(store)
-        elif key == '_config':
-            try:
-                config = mktl.config.get(store)
-            except KeyError:
-                payload_data = tuple()
-            else:
-                payload_data = config._by_uuid
-        else:
-            raise ValueError('unhandled key: ' + target)
-
+            payload_data = config._by_uuid
 
         payload = mktl.Payload(value=payload_data)
         return payload
 
 
-    def req_handler(self, request):
-        """ Inspect the incoming request type and decide how a response
-            will be generated.
-        """
-
-        if request.ack:
-            self.req_ack(request)
-
-        type = request.type
-        target = request.target
-
-        if type == 'GET':
-            payload = self.req_get(request)
-        elif type == 'SET':
-            payload = self.req_set(request)
-        else:
-            raise ValueError('unhandled request: ' + type)
-
-        if request.reply:
-            return payload
-
-
-    def req_set(self, request):
+    def req_set_config(self, request):
         """ We are expecting queries for configuration data, aimed
             at specially named built-in keys.
         """
@@ -454,7 +441,8 @@ class RequestServer(mktl.protocol.request.Server):
         return payload
 
 
-# end of class RequestServer
+# end of class RegistryDaemon
+
 
 
 class ProvenanceLoopError(RuntimeError):

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -13,6 +13,7 @@ if they already know where to find a registry.
 
 import argparse
 import logging
+import socket
 import sys
 import threading
 import time
@@ -31,7 +32,10 @@ def main():
 
     config = parse_command_line()
 
-    main.req = RequestServer()
+
+    store = 'registry:' + socket.getfqdn()
+
+    main.daemon = RegistryDaemon(store)
     main.beacon = mktl.protocol.discover.Server(main.req.port)
 
     delay = 30

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -268,7 +268,12 @@ class RegistryDaemon(mktl.Daemon):
                 request = mktl.protocol.message.Request('GET', store + '._config')
                 payload = mktl.protocol.request.send(address, port, request)
 
-                blocks = payload.value
+                try:
+                    blocks = payload.value
+                except AttributeError:
+                    # The request for the config threw an error; this shouldn't
+                    # occur, but here we are.
+                    continue
 
                 try:
                     error = payload.error
@@ -292,8 +297,18 @@ class RegistryDaemon(mktl.Daemon):
 
     def process_block(self, new):
 
-        print('processing: ' + repr(new))
         store = new['store']
+        store = store.lower()
+
+        # Dynamically update the request handling to know how to handle
+        # requests for the configuration for this store. Regardless of
+        # how we received a configuration block, the fact that we have
+        # a block at all implies we must be ready to answer queries for
+        # that store.
+
+        key = store + '._config'
+        self.rep._req_get_handlers[key] = self.req_get_config
+
         config = mktl.config.get(store)
 
         self.check_provenance(new)
@@ -399,12 +414,6 @@ class RegistryDaemon(mktl.Daemon):
         mktl.config.add_provenance(new, main.hostname, self.rep.port)
         port = new['provenance'][0]['rep']
         host = new['provenance'][0]['hostname']
-
-        # Dynamically update the request handling to know how to handle
-        # requests for the configuration for this store.
-
-        key = store + '._config'
-        self.rep._req_get_handlers[key] = self.req_get_config
 
         logger.info("remember: %s from %s:%s (%s)" % (alias, host, port, uuid))
         config.update(new)

--- a/src/mktl/config.py
+++ b/src/mktl/config.py
@@ -1296,14 +1296,14 @@ def add_provenance(block, hostname, rep, pub=None):
 
 
 def announce(config, uuid, override=False):
-    """ Announce an authoritative configuration to the local network.
-        Raise an exception if a conflict is detected. Setting *override*
-        to True will request any/all available recipients update their
-        local cache to clear any conflicting data.
+    """ Announce an authoritative configuration to the local network. This
+        announcement is received and processed by a registry, if one is
+        running. Raise an exception if the SET operation is rejected.
+        Setting *override* to True will request any/all available recipients
+        update their local cache to clear any conflicting data, though the
+        recipient may still reject the request if the conflicting daemon is
+        still online.
     """
-
-    store = config.store
-    key = store + '.config'
 
     block = config[uuid]
     block = dict(block)
@@ -1313,7 +1313,7 @@ def announce(config, uuid, override=False):
 
     payload = protocol.message.Payload(value=block)
     payload.add_origin()
-    message = protocol.message.Request('SET', key, payload)
+    message = protocol.message.Request('SET', '_config', payload)
 
     registries = protocol.discover.search(wait=True)
 


### PR DESCRIPTION
Rework the registry process to be a full mKTL daemon. This establishes a baseline that can be used to expand the available metadata for live inspection of what's happening internal to the registry process.

The base functionality remains unchanged, but the use of specially named items (_config, _hash) is now normalized. 