### PR TITLE
Change the strings used in the discovery exchange.

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -483,10 +483,10 @@ There are four shared secrets used in the discovery exchange:
 
 **call**	  An arbitrary string used by the discoverer to trigger a
 		  response from the listener. The string value is
-		  ``I heard it``.
+		  ``Aloha mKTL``.
 
 **response**	  An arbitrary string used by the listener to respond to any
-		  received calls. The string value is ``on the X:``.
+		  received calls. The string value is ``E komo mai:``.
 
 ================= ==============================================================
 
@@ -498,7 +498,7 @@ component of the response after the colon. For example, if a daemon has a
 request port listening on port 10079, the full exchange (discovery request,
 discovery response) would be::
 
-    b'I heard it'
+    b'Aloha mKTL'
 
-    b'on the X:10079'
+    b'E komo mai:10079'
 

--- a/src/mktl/protocol/discover.py
+++ b/src/mktl/protocol/discover.py
@@ -15,10 +15,10 @@ import time
 
 from .. import meta
 
-call = 'I heard it'
+call = 'Aloha mKTL'
 call = call.encode()
 
-response = 'on the X:'
+response = 'E komo mai:'
 response = response.encode()
 
 # There's nothing special about this port number, other than it is not


### PR DESCRIPTION
The call and response used in discovery were an obscure musical reference that was out-of-place in an mKTL context.