### PR TITLE
Small compatibility fixes

### DIFF
--- a/examples/KTL.py
+++ b/examples/KTL.py
@@ -103,7 +103,7 @@ class Item(mktl.Item):
         timestamp = slice.time
         unformatted = slice.binary
 
-        payload = mktl.Payload(unformatted, timestamp)
+        payload = mktl.Payload(value=unformatted, time=timestamp)
         return payload
 
 

--- a/examples/ktl2mktl
+++ b/examples/ktl2mktl
@@ -32,7 +32,7 @@ if KTL is None:
     try:
         import KTL
     except ImportError:
-        raise ImportError('unable to import either mktl or KTL.py')
+        raise ImportError('unable to import mktl.KTL')
 
 
 def main():

--- a/examples/ktl2mktl
+++ b/examples/ktl2mktl
@@ -15,7 +15,6 @@ For example, to run ktl2mktl for the KTL service 'kpfpower', one might invoke:
 
 import argparse
 import json
-import ktl
 import sys
 
 try:

--- a/sbin/mkregistryd
+++ b/sbin/mkregistryd
@@ -27,7 +27,15 @@ def main():
 
     config = parse_command_line()
     main.hostname = socket.getfqdn()
-    store = 'registry:' + main.hostname
+
+    # It's problematic to use the FQDN as part of the store name because
+    # a proper FQDN will have dot-separated fields, and mKTL relies on
+    # dot-separation for fully qualified item keys. The store name generated
+    # here is expected to be unique for this host; this may need to be
+    # revisited in the future.
+
+    sanitized_hostname = main.hostname.replace('.', '_')
+    store = 'registry:' + sanitized_hostname
 
     catalog = generate_catalog()
     mktl.meta.authoritative(store, store, catalog)

--- a/src/mktl/begin.py
+++ b/src/mktl/begin.py
@@ -149,7 +149,10 @@ def get(store, key=None):
         message = protocol.message.Request('GET', key)
         payload = protocol.request.send(hostname, port, message)
 
-        blocks = payload.value
+        try:
+            blocks = payload.value
+        except AttributeError:
+            blocks = None
 
         if blocks:
             for uuid,block in blocks.items():

--- a/src/mktl/daemon.py
+++ b/src/mktl/daemon.py
@@ -2,7 +2,6 @@
 import atexit
 import logging
 import os
-import platform
 import queue
 import resource
 import socket
@@ -521,7 +520,7 @@ class Daemon:
         items[key] = dict()
         items[key]['description'] = 'The hostname where this daemon is running.'
         items[key]['type'] = 'string'
-        items[key]['initial'] = platform.node()
+        items[key]['initial'] = socket.getfqdn()
         items[key]['settable'] = False
 
         key = '_' + self.alias + 'mem'

--- a/src/mktl/json.py
+++ b/src/mktl/json.py
@@ -5,19 +5,19 @@
 dumps = None
 loads = None
 
-# The msgspec 'encode' operation returns bytes, as does orjson.dumps(). To
-# maintain alignment all dumps() methods need to do so as well. The loads()
-# methods in each implementation will accept bytes as input.
-
-def json_dumps(*args, **kwargs):
-    return json.dumps(*args, **kwargs).encode()
-
 
 def use_json():
 
     import json
     global dumps
     global loads
+
+    # The msgspec 'encode' operation returns bytes, as does orjson.dumps(). To
+    # maintain alignment all dumps() methods need to do so as well. The loads()
+    # methods in each implementation will accept bytes as input.
+
+    def json_dumps(*args, **kwargs):
+        return json.dumps(*args, **kwargs).encode()
 
     # One could use cached instances of json.JSONEncoder and json.JSONDecoder
     # here, but it doesn't appear to be any more efficient than calling the

--- a/src/mktl/protocol/message.py
+++ b/src/mktl/protocol/message.py
@@ -5,7 +5,7 @@
 import itertools
 import logging
 import os
-import platform
+import socket
 import sys
 import threading
 import time
@@ -42,7 +42,7 @@ except:
     _origin_user = None
 
 try:
-    _origin_hostname = platform.node()
+    _origin_hostname = socket.getfqdn()
 except:
     _origin_hostname = None
 


### PR DESCRIPTION
Testing with a KTL-based daemon on an older Python interpreter turned up a few bootstrapping issues, some in the KTL example code, some in the error handling, and a few having to do with fully-qualified domain names.